### PR TITLE
fix: do not set default group name, close #50

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -54,9 +54,6 @@ default: `base-10`
 type: string
 
 
-default: `default group`
-
-
 **`parallel`**
 
 > Use test balancing using Cypress Dashboard,

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -158,7 +158,7 @@ jobs:
 
       group:
         type: string
-        default: 'default group'
+        default: ''
         description: |
           Test group name when recording on the dashboard. Requires `record: true`
 
@@ -263,7 +263,7 @@ jobs:
                     <<# parameters.spec>> --spec '<<parameters.spec>>' <</ parameters.spec>> \
                     <<# parameters.browser>> --browser <<parameters.browser>> <</ parameters.browser>> \
                     <<# parameters.record >> --record \
-                      --group '<<parameters.group>>' \
+                      <<# parameters.group>> --group '<<parameters.group>>' <</ parameters.group>> \
                       <<# parameters.parallel>> --parallel <</ parameters.parallel>> \
                     <</ parameters.record>>
 
@@ -478,8 +478,8 @@ examples:
 ## process this workflow using above jobs and commands like inline orb
 ## Useful for local developing, especially by showing the effective config
 ## using: npm run effective:config
-# workflows:
-#   build:
-#     jobs:
-#       - run:
-#           wait-on: http://localhost:4200
+workflows:
+  build:
+    jobs:
+      - run:
+          record: true


### PR DESCRIPTION
- closes #50 and avoids problems for people without parallelization feature in the plan