### PR TITLE
Add --frozen-lockfile flag to 'yarn install'

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -19,7 +19,7 @@ workflows:
 ## yarn
 
 
-Installs NPM dependencies using "yarn install" command
+Installs NPM dependencies using "yarn install --frozen-lockfile" command
 
 ```yaml
 version: 2.1

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -80,7 +80,7 @@ commands:
           steps:
             - run:
                 name: 'Yarn install'
-                command: 'yarn install'
+                command: 'yarn install --frozen-lockfile'
       - unless:
           condition: << parameters.yarn >>
           steps:
@@ -121,7 +121,7 @@ commands:
   # Install command
   install:
     description: |
-      Install NPM dependencies using "npm ci" or "yarn install" then optionally runs your build command
+      Install NPM dependencies using "npm ci" or "yarn install --frozen-lockfile" then optionally runs your build command
     parameters:
       build:
         type: steps
@@ -367,7 +367,7 @@ examples:
             - cypress/run
 
   yarn:
-    description: Installs NPM dependencies using "yarn install" command
+    description: Installs NPM dependencies using "yarn install --frozen-lockfile" command
     usage:
       version: 2.1
       orbs:


### PR DESCRIPTION
Resolves #72 by passing the `--frozen-lockfile` flag when running `yarn install` in the `setup` command and updating the relevant docs.