### PR TITLE
Fix readme version issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Install dependencies (using `npm ci`) and run all Cypress tests:
 version: 2.1
 orbs:
   # import Cypress orb by specifying an exact version
-  cypress: cypress-io/cypress@1.1.0
+  cypress: cypress-io/cypress@x.x.x
 workflows:
   build:
     jobs:
@@ -38,7 +38,7 @@ Runs all Cypress tests and records them on the Cypress Dashboard
 ```yaml
 version: 2.1
 orbs:
-  cypress: cypress-io/cypress@1.1.0
+  cypress: cypress-io/cypress@x.x.x
 workflows:
   build:
     jobs:
@@ -53,7 +53,7 @@ A more complex project that needs to install dependencies, build an application 
 ```yaml
 version: 2.1
 orbs:
-  cypress: cypress-io/cypress@1.1.0
+  cypress: cypress-io/cypress@x.x.x
 workflows:
   build:
     jobs:
@@ -113,7 +113,7 @@ A typical example:
 version: 2.1
 orbs:
   # import Cypress orb by specifying an exact version
-  cypress: cypress-io/cypress@1.1.0
+  cypress: cypress-io/cypress@x.x.x
 workflows:
   build:
     jobs:
@@ -135,7 +135,7 @@ Sometimes you need to install the project's npm dependencies and build the appli
 ```yaml
 version: 2.1
 orbs:
-  cypress: cypress-io/cypress@1.1.0
+  cypress: cypress-io/cypress@x.x.x
 workflows:
   build:
     jobs:
@@ -180,7 +180,7 @@ For example, if your current CircleCI configuration file is `.circleci/config.ym
 ```yaml
 version: 2.1
 orbs:
-  cypress: cypress-io/cypress@1.1.0
+  cypress: cypress-io/cypress@x.x.x
 workflows:
   build:
     jobs:
@@ -191,7 +191,7 @@ The fully resolved configuration will show:
 
 ```shell
 $ circleci config process .circleci/config.yml
-# Orb 'cypress-io/cypress@1.1.0' resolved to 'cypress-io/cypress@1.1.0'
+# Orb 'cypress-io/cypress@x.x.x' resolved to 'cypress-io/cypress@x.x.x'
 version: 2
 jobs:
   cypress/run:


### PR DESCRIPTION
Remove the specific version in Readme as it is confusing for people who first starting using the Orb, especially when the version is out of the date.