### PR TITLE
Add chrome 73-76 to the executors

### DIFF
--- a/docs/executors.md
+++ b/docs/executors.md
@@ -51,3 +51,35 @@ Docker container with Node 10, Cypress dependencies and Chrome 69
 
 Docker image: `cypress/browsers:chrome69`
 
+## browsers-chrome73
+
+
+Docker container with Node 11.13.0, Cypress dependencies and Chrome 73
+
+
+Docker image: `cypress/browsers:node11.13.0-chrome73`
+
+## browsers-chrome74
+
+
+Docker container with Node 10.1.2, Cypress dependencies and Chrome 74
+
+
+Docker image: `cypress/browsers:node10.2.1-chrome74`
+
+## browsers-chrome75
+
+
+Docker container with Node 12.6.0, Cypress dependencies and Chrome 75
+
+
+Docker image: `cypress/browsers:node12.6.0-chrome75`
+
+## browsers-chrome76
+
+
+Docker container with Node 10.16.0, Cypress dependencies and Chrome 69
+
+
+Docker image: `cypress/browsers:node10.16.0-chrome76`
+

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -55,6 +55,25 @@ executors:
     docker:
       - image: cypress/browsers:chrome69
 
+  browsers-chrome73:
+    description: Docker container with Node 11.13.0, Cypress dependencies and Chrome 73
+    docker:
+      - image: cypress/browsers:node11.13.0-chrome73
+
+  browsers-chrome74:
+    description: Docker container with Node 10.1.2, Cypress dependencies and Chrome 74
+    docker:
+      - image: cypress/browsers:node10.2.1-chrome74
+
+  browsers-chrome75:
+    description: Docker container with Node 12.6.0, Cypress dependencies and Chrome 75
+    docker:
+      - image: cypress/browsers:node12.6.0-chrome75
+
+  browsers-chrome76:
+    description: Docker container with Node 10.16.0, Cypress dependencies and Chrome 69
+    docker:
+      - image: cypress/browsers:node10.16.0-chrome76
 #
 # reusable commands
 #

--- a/test/simple.test.ts
+++ b/test/simple.test.ts
@@ -42,3 +42,21 @@ test('parallel 2 machines', t => {
   `
   return processWorkflows(workflows)
 })
+
+test('Use non-default executors', async t => {
+  t.plan(0)
+  const executors = ['cypress/browsers-chrome69', 'cypress/browsers-chrome73',
+    'cypress/browsers-chrome74', 'cypress/browsers-chrome75', 'cypress/browsers-chrome76']
+  for (let ex of executors) {
+    const workflows = stripIndent`
+      workflows:
+        build:
+          jobs:
+            - cypress/install:
+                executor: ${ex}
+            - cypress/run:
+                executor: ${ex}
+    `
+    await processWorkflows(workflows)
+  }
+})


### PR DESCRIPTION
I added Chrome 73 to 76 to the executors with the existing docker images (https://hub.docker.com/r/cypress/browsers/tags).

I have included a new test in simple.test.ts to ensure the executors can be used with cypress/run and cypress/install.

Note:
I have not published this change as a dev version to the CircleCI orb repo yet. Are the Cypress developer welcoming other people to publish CircleCI orbs?