### PR TITLE
Add post install step

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -25,6 +25,7 @@
  - [private-npm-module](#private-npm-module) - complete NPM module publishing example
  - [custom-directory](#custom-directory) - run commands in a subfolder of a monorepo
  - [custom-cache-and-directory](#custom-cache-and-directory) - use custom cache key in a monorepo situation
+ - [install-extra-tool](#install-extra-tool) - run commands after installing NPM modules but before caching
 
 ## simple
 
@@ -517,6 +518,25 @@ workflows:
             cache-{{ arch }}-{{ .Branch }}-{{ checksum "frontend/package.json"
             }}
           working_directory: frontend
+
+```
+
+## install-extra-tool
+
+
+Sometimes you want to install another tool after installing regular dependencies but before running "cypress verify" and caching NPM modules and Cypress binary. In this example, it installs one more tool "print-env" and runs it. 
+
+```yaml
+version: 2.1
+orbs:
+  cypress: cypress-io/cypress@1
+workflows:
+  build:
+    jobs:
+      - cypress/run:
+          post-install:
+            - run: npm install -g print-env
+            - run: print-env CIRCLE
 
 ```
 

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -10,6 +10,7 @@ Public jobs defined in this orb that your config workflow can use. See [examples
      - parallel
      - parallelism
      - group
+     - post-install
      - build
      - start
      - wait-on
@@ -25,6 +26,7 @@ Public jobs defined in this orb that your config workflow can use. See [examples
     
  - [install](#install)
      - executor
+     - post-install
      - build
      - cache-key
      - yarn
@@ -131,6 +133,18 @@ type: integer
 
 
 default: `1`
+
+
+**`post-install`**
+
+> Additional commands to run after running install
+> but before verifying Cypress and saving cache.
+
+
+type: steps
+
+
+default: ``
 
 
 **`record`**
@@ -249,6 +263,18 @@ type: executor
 
 
 default: `base-10`
+
+
+**`post-install`**
+
+> Additional commands to run after running install
+> but before verifying Cypress and saving cache.
+
+
+type: steps
+
+
+default: ``
 
 
 **`working_directory`**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "circleci-orb",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "circleci-orb",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Install, cache and run Cypress.io tests on CircleCI with minimal configuration.",
   "main": "index.js",
   "scripts": {

--- a/scripts/examples.ts
+++ b/scripts/examples.ts
@@ -34,6 +34,7 @@ const exampleTitles = {
   'private-npm-module': 'complete NPM module publishing example',
   'custom-directory': 'run commands in a subfolder of a monorepo',
   'custom-cache-and-directory': 'use custom cache key in a monorepo situation',
+  'install-extra-tool': 'run commands after installing NPM modules but before caching',
 }
 
 // we want to make sure all orb examples are represented in the object above

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -93,6 +93,12 @@ commands:
         description: Executor to use
         type: executor
         default: base-10
+      post-install:
+        description: |
+          Additional commands to run after running install
+          but before verifying Cypress and saving cache.
+        type: steps
+        default: []
       build:
         description: Optional build command(s)
         type: steps
@@ -139,6 +145,7 @@ commands:
                 name: 'Npm CI'
                 command: 'npm ci'
                 working_directory: << parameters.working_directory >>
+      - steps: << parameters.post-install >>
       - run:
           name: 'Verify Cypress'
           command: npx cypress verify
@@ -178,6 +185,12 @@ commands:
     description: |
       Install NPM dependencies using "npm ci" or "yarn install --frozen-lockfile" then optionally runs your build command
     parameters:
+      post-install:
+        description: |
+          Additional commands to run after running install
+          but before verifying Cypress and saving cache.
+        type: steps
+        default: []
       build:
         type: steps
         default: []
@@ -201,9 +214,10 @@ commands:
         default: ''
     steps:
       - setup:
-          build: << parameters.build >>
+          post-install: << parameters.post-install >>
           yarn: << parameters.yarn >>
           cache-key: << parameters.cache-key >>
+          build: << parameters.build >>
           working_directory: << parameters.working_directory >>
       - unless:
           condition: << parameters.no-workspace >>
@@ -266,6 +280,13 @@ jobs:
         default: ''
         description: |
           Test group name when recording on the dashboard. Requires `record: true`
+
+      post-install:
+        description: |
+          Additional commands to run after running install
+          but before verifying Cypress and saving cache.
+        type: steps
+        default: []
 
       build:
         type: string
@@ -370,6 +391,7 @@ jobs:
                 steps:
                   - install:
                       yarn: << parameters.yarn >>
+                      post-install: << parameters.post-install >>
                       cache-key: << parameters.cache-key >>
                       no-workspace: << parameters.no-workspace >>
                       build:
@@ -381,6 +403,7 @@ jobs:
                   - install:
                       cache-key: << parameters.cache-key >>
                       yarn: << parameters.yarn >>
+                      post-install: << parameters.post-install >>
                       no-workspace: << parameters.no-workspace >>
                       working_directory: << parameters.working_directory >>
 
@@ -444,6 +467,12 @@ jobs:
         type: executor
         default: base-10
         description: Cypress or custom executor name to use to run the install.
+      post-install:
+        description: |
+          Additional commands to run after running install
+          but before verifying Cypress and saving cache.
+        type: steps
+        default: []
       build:
         type: string
         default: ''
@@ -476,6 +505,7 @@ jobs:
           steps:
             - install:
                 yarn: << parameters.yarn >>
+                post-install: << parameters.post-install >>
                 build:
                   - run:
                       name: 'Build'
@@ -487,6 +517,7 @@ jobs:
           steps:
             - install:
                 yarn: << parameters.yarn >>
+                post-install: << parameters.post-install >>
                 working_directory: << parameters.working_directory >>
                 cache-key: << parameters.cache-key >>
 
@@ -937,6 +968,22 @@ examples:
                 post-steps:
                   - run: npm run semantic-release
 
+  install-extra-tool:
+    description: |
+      Sometimes you want to install another tool after installing regular dependencies
+      but before running "cypress verify" and caching NPM modules and Cypress binary.
+      In this example, it installs one more tool "print-env" and runs it.
+    usage:
+      version: 2.1
+      orbs:
+        cypress: cypress-io/cypress@1
+      workflows:
+        build:
+          jobs:
+            - cypress/run:
+                post-install:
+                  - run: npm install -g print-env
+                  - run: print-env CIRCLE
 ##
 ## Development (internal)
 ##
@@ -947,4 +994,6 @@ examples:
 #   build:
 #     jobs:
 #       - run:
+#           post-install:
+#             - run: 'echo built it'
 #           no-workspace: true


### PR DESCRIPTION
For example, this will allow us to install Cypress pre-release and cache it.

```yaml
- cypress/run:
    post-install:
      - run:
          name: Install Cypress pre-release
          environment:
            CYPRESS_INSTALL_BINARY: https://cdn.cypress.io/beta/binary/3.6.1/linux-x64/circle-issue-1096-firefox-support-42fcf58b442cc6bdbc35f3d5e2c34682f910badc-184089/cypress.zip
          command: npm install https://cdn.cypress.io/beta/npm/3.6.1/circle-issue-1096-firefox-support-42fcf58b442cc6bdbc35f3d5e2c34682f910badc-184085/cypress.tgz
    executor: cypress/browsers-chrome73-ff68
```