### PR TITLE
feat: Include Chrome 77-78 in the executors

### DIFF
--- a/docs/executors.md
+++ b/docs/executors.md
@@ -78,10 +78,26 @@ Docker image: `cypress/browsers:node12.6.0-chrome75`
 ## browsers-chrome76
 
 
-Docker container with Node 10.16.0, Cypress dependencies and Chrome 69
+Docker container with Node 10.16.0, Cypress dependencies and Chrome 76
 
 
 Docker image: `cypress/browsers:node10.16.0-chrome76`
+
+## browsers-chrome77
+
+
+Docker container with Node 12.6.0, Cypress dependencies and Chrome 77
+
+
+Docker image: `cypress/browsers:node12.6.0-chrome77`
+
+## browsers-chrome78-ff70
+
+
+Docker container with Node 12.13.0, Cypress dependencies and Chrome 78 and Firefox 70
+
+
+Docker image: `cypress/browsers:node12.13.0-chrome78-ff70`
 
 ## browsers-chrome73-ff68
 

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -71,9 +71,19 @@ executors:
       - image: cypress/browsers:node12.6.0-chrome75
 
   browsers-chrome76:
-    description: Docker container with Node 10.16.0, Cypress dependencies and Chrome 69
+    description: Docker container with Node 10.16.0, Cypress dependencies and Chrome 76
     docker:
       - image: cypress/browsers:node10.16.0-chrome76
+
+  browsers-chrome77:
+    description: Docker container with Node 12.6.0, Cypress dependencies and Chrome 77
+    docker:
+      - image: cypress/browsers:node12.6.0-chrome77
+
+  browsers-chrome78-ff70:
+    description: Docker container with Node 12.13.0, Cypress dependencies and Chrome 78 and Firefox 70
+    docker:
+      - image: cypress/browsers:node12.13.0-chrome78-ff70
 
   browsers-chrome73-ff68:
     description: Docker container with Node 12.0.0, Cypress dependencies, Chrome 73 and Firefox 68.0.2


### PR DESCRIPTION
Please have Chrome 77 and Chrome 78 available in the executors.

A typo has been fixed for Chrome 76 executor documentation.

Let me leave the Cypress maintainers to publish a new version of the orb. :)

P.S. In the future, should we remove some very old versions of Chrome in the future orb releases?  I haven't found any way to do a "include" in the orb.yml file.  If we keep adding executors, the file is getting hairy.