### PR TITLE
Add Home URL and Source Code URL

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -3,7 +3,10 @@ description: |
   Run your Cypress.io end-to-end browser tests without spending time configuring CircleCI.
   This orb can also record results on the Cypress Dashboard and load balance tests in parallel mode.
   If recording on the dashboard, set `CYPRESS_RECORD_KEY` as CI environment variable.
-  Repo: https://github.com/cypress-io/circleci-orb
+
+display:
+  source_url: https://github.com/cypress-io/circleci-orb
+  home_url: Cypress.io
 
 #
 # See https://www.cypress.io/


### PR DESCRIPTION
Display a link to your home page and the orb source natively in the Orb registry as a clickable link.