### PR TITLE
feat: add ci-build-id run job parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ In all cases, you are using `run` and `install` job definitions that Cypress pro
 - [tag recorded run](docs/examples.md#tags)
 - [run different tests depending on the branch](docs/examples.md#run-on-master-branch)
 - [turn on specific DEBUG logs](docs/examples#debug)
+- [use custom `ci-build-id`](docs/examples#custom-build-id)
 
 All examples are in [docs/examples.md](docs/examples.md) and are generated from the [src/orb.yml](src/orb.yml) file.
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -36,6 +36,7 @@
  - [run-tasks-post-checkout](#run-tasks-post-checkout) - perform steps after code checkout but before installing dependencies
  - [run-on-master-branch](#run-on-master-branch) - run different tests depending on the branch
  - [debug](#debug) - turn on specific DEBUG logs
+ - [custom-build-id](#custom-build-id) - Using custom ci-build-id parameter to tie jobs into a logical run
 
 ## simple
 
@@ -700,5 +701,27 @@ workflows:
       - cypress/run:
           name: Debug with Cypress CLI logs
           debug: 'cypress:cli'
+```
+
+## custom-build-id
+
+
+Runs two jobs splitting the specs in parallel using Cypress Dashboard [parallelization](https://on.cypress.io/parallelization). Uses custom build ID to link the jobs together into a logical run 
+
+```yaml
+version: 2.1
+orbs:
+  cypress: cypress-io/cypress@1
+workflows:
+  build:
+    jobs:
+      - cypress/install
+      - cypress/run:
+          requires:
+            - cypress/install
+          record: true
+          parallel: true
+          parallelism: 2
+          ci-build-id: testing-commit-$CIRCLE_SHA1
 ```
 

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -11,6 +11,7 @@ Public jobs defined in this orb that your config workflow can use. See [examples
      - record
      - parallel
      - parallelism
+     - ci-build-id
      - group
      - tags
      - post-install
@@ -91,6 +92,15 @@ type: string
 
 
 default: `cache-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}`
+
+
+**`ci-build-id`**
+
+> A common unique ID that ties multiple test jobs into a single logical run.
+> See [parallelization docs](https://on.cypress.io/parallelization)
+
+
+type: string
 
 
 **`command`**

--- a/scripts/examples.ts
+++ b/scripts/examples.ts
@@ -53,6 +53,8 @@ const exampleTitles = {
     'perform steps after code checkout but before installing dependencies',
   'run-on-master-branch': 'run different tests depending on the branch',
   debug: 'turn on specific DEBUG logs',
+  'custom-build-id':
+    'Using custom ci-build-id parameter to tie jobs into a logical run',
 }
 
 // we want to make sure all orb examples are represented in the object above

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -363,6 +363,13 @@ jobs:
           Number of Circle machines to use for load balancing, min 1
           (requires "parallel" parameter set to true, and requires `record: true`)
 
+      ci-build-id:
+        type: string
+        default: ''
+        description: |
+          A common unique ID that ties multiple test jobs into a single logical run.
+          See [parallelization docs](https://on.cypress.io/parallelization)
+
       group:
         type: string
         default: ''
@@ -615,6 +622,7 @@ jobs:
                             <<# parameters.group>> --group '<<parameters.group>>' <</ parameters.group>> \
                             <<# parameters.parallel>> --parallel <</ parameters.parallel>> \
                             <<# parameters.tags>> --tag '<<parameters.tags>>' <</ parameters.tags>> \
+                            <<# parameters.ci-build-id>> --ci-build-id '<<parameters.ci-build-id>>' <</ parameters.ci-build-id>> \
                           <</ parameters.record>>
                       working_directory: << parameters.working_directory >>
             - unless:
@@ -635,6 +643,7 @@ jobs:
                             <<# parameters.group>> --group '<<parameters.group>>' <</ parameters.group>> \
                             <<# parameters.parallel>> --parallel <</ parameters.parallel>> \
                             <<# parameters.tags>> --tag '<<parameters.tags>>' <</ parameters.tags>> \
+                            <<# parameters.ci-build-id>> --ci-build-id '<<parameters.ci-build-id>>' <</ parameters.ci-build-id>> \
                           <</ parameters.record>>
                       working_directory: << parameters.working_directory >>
 
@@ -986,6 +995,27 @@ examples:
                 parallel: true
                 parallelism: 2
                 group: '2 machines'
+
+  custom-build-id:
+    description: |
+      Runs two jobs splitting the specs in parallel using
+      Cypress Dashboard [parallelization](https://on.cypress.io/parallelization).
+      Uses custom build ID to link the jobs together into a logical run
+    usage:
+      version: 2.1
+      orbs:
+        cypress: cypress-io/cypress@1
+      workflows:
+        build:
+          jobs:
+            - cypress/install
+            - cypress/run:
+                requires:
+                  - cypress/install
+                record: true
+                parallel: true
+                parallelism: 2
+                ci-build-id: testing-commit-$CIRCLE_SHA1
 
   install-private-npm-modules:
     description: |
@@ -1370,5 +1400,5 @@ examples:
 #   build:
 #     jobs:
 #       - run:
-#           store_artifacts: true
-#           working_directory: foo/bar
+#           record: true
+#           ci-build-id: test-run-commit-$CIRCLE_SHA1


### PR DESCRIPTION
- closes #295

```yml
version: 2.1
orbs:
  cypress: cypress-io/cypress@1
workflows:
  build:
    jobs:
      - cypress/install
      - cypress/run:
          requires:
            - cypress/install
          record: true
          parallel: true
          parallelism: 2
          ci-build-id: testing-commit-$CIRCLE_SHA1
```