### PR TITLE
feat: pass the working directory with build command to the install job

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,12 @@ Because we need to see the effective config for a few basic orb uses, please ins
 npm run manual:tests
 ```
 
+If you want to run a single test file
+
+```shell
+npx ava-ts manual-tests/<filename>.ts
+```
+
 Any changes that modify the effective configs will probably not match previously saved snapshots.
 
 ### Production

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -147,6 +147,9 @@ export const effectiveConfig = (workflows: string): Promise<any> => {
 export const removeNewLines = (runCommand: string) =>
   runCommand.replace(/\\\n/g, '').replace(/\s+/g, ' ').trim()
 
+/**
+ * Given Circle YML text finds the Cypress run command object.
+ */
 export const extractCypressRun = (circleText: string) => {
   const parsed = yaml.safeLoad(circleText)
   debug('parsed %o', parsed)
@@ -158,4 +161,23 @@ export const extractCypressRun = (circleText: string) => {
   runTestsStep.run.command = removeNewLines(runTestsStep.run.command)
 
   return runTestsStep.run
+}
+
+/**
+ * Given Circle YML text finds the build command object.
+ */
+export const extractBuildStep = (
+  circleText: string,
+  jobName: string = 'cypress/run',
+) => {
+  const parsed = yaml.safeLoad(circleText)
+  debug('parsed %o', parsed)
+
+  const isBuildStep = (step) => step.run && step.run.name === 'Build'
+  const found = find(isBuildStep)(parsed.jobs[jobName].steps)
+  debug('found build step %o', found)
+
+  found.run.command = removeNewLines(found.run.command)
+
+  return found.run
 }

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -194,9 +194,9 @@ commands:
         type: steps
         default: []
       build:
-        description: Optional build command(s)
-        type: steps
-        default: []
+        description: Optional build command
+        type: string
+        default: ''
       install-command:
         description: Overrides the default NPM or Yarn command
         type: string
@@ -265,7 +265,13 @@ commands:
                 paths:
                   - ~/.npm
                   - ~/.cache
-      - steps: << parameters.build >>
+      - when:
+          condition: << parameters.build >>
+          steps:
+            - run:
+                name: 'Build'
+                command: << parameters.build >>
+                working_directory: << parameters.working_directory >>
 
   write_workspace:
     steps:
@@ -291,9 +297,9 @@ commands:
         type: steps
         default: []
       build:
-        type: steps
-        default: []
-        description: Custom build commands to run after install
+        type: string
+        default: ''
+        description: Custom build command to run after install
       yarn:
         description: Use yarn instead of npm
         type: boolean
@@ -593,8 +599,7 @@ jobs:
                             post-install: << parameters.post-install >>
                             cache-key: << parameters.cache-key >>
                             no-workspace: << parameters.no-workspace >>
-                            build:
-                              - run: << parameters.build >>
+                            build: << parameters.build >>
                             working_directory: << parameters.working_directory >>
                   - unless:
                       condition: <<parameters.build>>
@@ -769,10 +774,7 @@ jobs:
                 verify-command: << parameters.verify-command >>
                 yarn: << parameters.yarn >>
                 post-install: << parameters.post-install >>
-                build:
-                  - run:
-                      name: 'Build'
-                      command: << parameters.build >>
+                build: << parameters.build >>
                 working_directory: << parameters.working_directory >>
                 cache-key: << parameters.cache-key >>
       - unless:


### PR DESCRIPTION
- closes #315 
- passes `working_directory` and applies to the `build` step

Note: before the build command was declared as "steps" internally, but seems we can just use a string, since we never passed multiple commands.