### PR TITLE
fix: only attach workspace when required

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -566,7 +566,8 @@ jobs:
                   echo 'export DEBUG="<< parameters.debug >>"' >> $BASH_ENV
 
       - when:
-          condition: << parameters.parallel >> << parameters.attach-workspace >>
+          condition:
+            or: [ << parameters.parallel >>, << parameters.attach-workspace >> ]
           # user wants to run in parallel mode
           # thus we assume the dependencies were installed as separate job
           # hmm, can we detect if this job requires cypress/install automatically?


### PR DESCRIPTION
My cypress/run CI job is currently failing due to
> Directory (/home/circleci/project) you are trying to checkout to is not empty and not a git repository
because the following steps are always applied:
```
    - attach_workspace:
        at: ~/
    - checkout
```

`checkout` should only be present when you're not attaching a workspace, but currently, `attach-workspace: false` doesn't stop workspaces being attached due to the broken conditional, hence the job failing if the workspace has anything inside it.

Fixes https://github.com/cypress-io/circleci-orb/issues/293