### PR TITLE
fix: update image per circleci best practices.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: circleci/node:10
+      - image: cimg/node:16
 
     working_directory: ~/repo
 
@@ -35,4 +35,4 @@ jobs:
 workflows:
   orb_tests:
     jobs:
-    - build
+      - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: cimg/node:16
+      - image: cimg/node:16.14.2
 
     working_directory: ~/repo
 


### PR DESCRIPTION
Updates `config.yml` to use `cimg/node:16.14.2` which is a CircleCI best practice and the same Node version we currently test against in our cypress-docker-images repo. 

Fixes #365 