### PR TITLE
docs: more version updates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Install dependencies (using `npm ci`) and run all Cypress tests:
 version: 2.1
 orbs:
   # import Cypress orb by specifying an exact version x.y.z
-  # or the latest version 1.x.x using "@1" syntax
+  # or the latest version 2.x.x using "@2" syntax
   cypress: cypress-io/cypress@2
 workflows:
   build:
@@ -63,7 +63,7 @@ Install dependencies (using `npm ci`) and run all Cypress component tests:
 version: 2.1
 orbs:
   # import Cypress orb by specifying an exact version x.y.z
-  # or the latest version 1.x.x using "@1" syntax
+  # or the latest version 2.x.x using "@2" syntax
   cypress: cypress-io/cypress@2
 workflows:
   build:

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -64,7 +64,7 @@ Runs all Cypress component tests without recording results on the Dashboard. Ins
 ```yaml
 version: 2.1
 orbs:
-  cypress: cypress-io/cypress@2.2.0
+  cypress: cypress-io/cypress@2
 workflows:
   build:
     jobs:

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -253,7 +253,7 @@ orbs:
   cypress: cypress-io/cypress@2
   # for testing on Windows
   # https://circleci.com/docs/2.0/hello-world-windows/
-  win: circleci/windows@1
+  win: circleci/windows@5.0.0
 workflows:
   build:
     jobs:


### PR DESCRIPTION
I noticed a couple of other places that `v1` was still referenced. Our reference to the Windows Orb was also very outdated.