### PR TITLE
feat: add default cypress base image

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -1,12 +1,4 @@
 description: >
-  This is a sample executor using Docker and Node. If you want to provide a custom environment in your orb, insert your image here.
-  If you do not require an executor, you can simply delete this directory.
+  A single complete job to run Cypress tests in your project
 docker:
-  - image: 'cimg/node:<<parameters.tag>>'
-parameters:
-  tag:
-    default: lts
-    description: >
-      Pick a specific cimg/node image variant:
-      https://hub.docker.com/r/cimg/node/tags
-    type: string
+  - image: cypress/base:16.16.0

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -2,3 +2,4 @@ description: >
   Single Docker container with Node 16.16.0 and Cypress dependencies
 docker:
   - image: cypress/base:16.16.0
+  

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -1,4 +1,4 @@
 description: >
-  A single complete job to run Cypress tests in your project
+  Single Docker container with Node 16.16.0 and Cypress dependencies
 docker:
   - image: cypress/base:16.16.0

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -2,4 +2,3 @@ description: >
   Single Docker container with Node 16.16.0 and Cypress dependencies
 docker:
   - image: cypress/base:16.16.0
-  


### PR DESCRIPTION
This is a small PR that assigns the default executor to the cypress base docker image of 16.16