### PR TITLE
feat: use node orb

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -12,15 +12,18 @@ workflows:
       # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
       - cypress/run:
           filters: *filters
+          name: Standard Npm Example
           working-directory: examples/simple
           cache-key: cache-{{ arch }}-{{ checksum "examples/simple/package.json" }}
       - cypress/run:
           filters: *filters
+          name: Yarn Example
           working-directory: examples/yarn
           cache-key: cache-{{ arch }}-{{ checksum "examples/yarn/package.json" }}
           pkg-manager: 'yarn'
       - cypress/run:
           filters: *filters
+          name: Custom Install Example
           working-directory: examples/custom-install
           install-command: npm run custom-install
           cache-key: cache-{{ arch }}-{{ checksum "examples/custom-install/package.json" }}
@@ -32,9 +35,15 @@ workflows:
           pub-type: production
           requires:
             - orb-tools/pack
+            - Standard Npm Example
+            - Yarn Example
+            - Custom Install Example
+
           context: circleci-orb-publishing
           filters:
             branches:
               ignore: /.*/
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+
+# VS Code Extension Version: 1.5.1

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -14,19 +14,19 @@ workflows:
           filters: *filters
           name: Standard Npm Example
           working-directory: examples/simple
-          cache-key: cache-{{ arch }}-{{ checksum "examples/simple/package.json" }}
+          cache-key: cypress-cache-{{ arch }}-{{ checksum "examples/simple/package.json" }}
       - cypress/run:
           filters: *filters
           name: Yarn Example
           working-directory: examples/yarn
-          cache-key: cache-{{ arch }}-{{ checksum "examples/yarn/package.json" }}
+          cache-key: cypress-cache-{{ arch }}-{{ checksum "examples/yarn/package.json" }}
           package-manager: 'yarn'
       - cypress/run:
           filters: *filters
           name: Custom Install Example
           working-directory: examples/custom-install
           install-command: npm run custom-install
-          cache-key: cache-{{ arch }}-{{ checksum "examples/custom-install/package.json" }}
+          cache-key: cypress-cache-{{ arch }}-{{ checksum "examples/custom-install/package.json" }}
       - orb-tools/pack:
           filters: *filters
       - orb-tools/publish:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -20,7 +20,7 @@ workflows:
           name: Yarn Example
           working-directory: examples/yarn
           cache-key: cache-{{ arch }}-{{ checksum "examples/yarn/package.json" }}
-          pkg-manager: 'yarn'
+          package-manager: 'yarn'
       - cypress/run:
           filters: *filters
           name: Custom Install Example

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -18,6 +18,7 @@ workflows:
           filters: *filters
           working-directory: examples/yarn
           cache-key: cache-{{ arch }}-{{ checksum "examples/yarn/package.json" }}
+          pkg-manager: 'yarn'
       - cypress/run:
           filters: *filters
           working-directory: examples/custom-install

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -9,4 +9,4 @@ display:
 
 # if our orb requires other orbs, we can import them like this. Otherwise remove the "orbs" stanza.
 orbs:
-  run: circleci/node@5
+  node: circleci/node@5

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -8,5 +8,5 @@ display:
   source_url: "https://github.com/cypress-io/circleci-orb"
 
 # if our orb requires other orbs, we can import them like this. Otherwise remove the "orbs" stanza.
-# orbs:
-#   hello: circleci/hello-build@0.0.5
+orbs:
+  run: circleci/node@5

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -29,31 +29,35 @@ steps:
   - run:
       name: "List Working Directory"
       command: ls -l
-  - restore_cache:
-      key: << parameters.cache-key >>
-  # we can install dependencies using "npm ci" or the
-  # user-supplied "install-command".
-  - run:
-      environment:
-        INSTALL_COMMAND: << parameters.install-command >>
-      name: Install
-      working_directory: << parameters.working-directory >>
-      command: <<include(scripts/run-install.sh)>>
-  - steps: << parameters.post-install >>
-  - when:
-      condition:
-        equal: [ "true", -f yarn.lock ]
-      steps:
-        - save_cache:
-            key: << parameters.cache-key >>
-            paths:
-              - ~/.cache
-  - unless:
-      condition:
-        equal: [ "true", -f yarn.lock ]
-      steps:
-        - save_cache:
-            key: << parameters.cache-key >>
-            paths:
-              - ~/.cache
-              - ~/.npm
+  - node/install:
+      override-ci-command: << parameters.install-command >>
+      app-dir: << parameters.working-directory >>
+  
+  # - restore_cache:
+  #     key: << parameters.cache-key >>
+  # # we can install dependencies using "npm ci" or the
+  # # user-supplied "install-command".
+  # - run:
+  #     environment:
+  #       INSTALL_COMMAND: << parameters.install-command >>
+  #     name: Install
+  #     working_directory: << parameters.working-directory >>
+  #     command: <<include(scripts/run-install.sh)>>
+  # - steps: << parameters.post-install >>
+  # - when:
+  #     condition:
+  #       equal: [ "true", -f yarn.lock ]
+  #     steps:
+  #       - save_cache:
+  #           key: << parameters.cache-key >>
+  #           paths:
+  #             - ~/.cache
+  # - unless:
+  #     condition:
+  #       equal: [ "true", -f yarn.lock ]
+  #     steps:
+  #       - save_cache:
+  #           key: << parameters.cache-key >>
+  #           paths:
+  #             - ~/.cache
+  #             - ~/.npm

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -23,6 +23,11 @@ parameters:
     description: Directory containing package.json
     type: string
     default: ''
+  pkg-manager:
+    type: enum
+    enum: ['npm', 'yarn', 'yarn-berry']
+    default: 'npm'
+    description: Select the default node package manager to use. NPM v5+ Required.
 
 steps:
   - checkout
@@ -32,6 +37,8 @@ steps:
   - node/install-packages:
       override-ci-command: << parameters.install-command >>
       app-dir: << parameters.working-directory >>
+      pkg-manager: << parameters.pkg-manager >>
+      
 
 
   # - restore_cache:

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -23,7 +23,7 @@ parameters:
     description: Directory containing package.json
     type: string
     default: ''
-  pkg-manager:
+  package-manager:
     type: enum
     enum: ['npm', 'yarn', 'yarn-berry']
     default: 'npm'
@@ -42,4 +42,4 @@ steps:
   - node/install-packages:
       override-ci-command: << parameters.install-command >>
       app-dir: << parameters.working-directory >>
-      pkg-manager: << parameters.pkg-manager >>
+      pkg-manager: << parameters.package-manager >>

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -31,39 +31,15 @@ parameters:
 
 steps:
   - checkout
-  - run:
-      name: "List Working Directory"
-      command: ls -l
+  - restore_cache:
+      name: Restore Cypress cache
+      key: << parameters.cache-key >>
+  - save_cache:
+      name: Save Cypress Binary
+      key: << parameters.cache-key >>
+      paths:
+        - ~/.cache
   - node/install-packages:
       override-ci-command: << parameters.install-command >>
       app-dir: << parameters.working-directory >>
       pkg-manager: << parameters.pkg-manager >>
-
-  # - restore_cache:
-  #     key: << parameters.cache-key >>
-  # # we can install dependencies using "npm ci" or the
-  # # user-supplied "install-command".
-  # - run:
-  #     environment:
-  #       INSTALL_COMMAND: << parameters.install-command >>
-  #     name: Install
-  #     working_directory: << parameters.working-directory >>
-  #     command: <<include(scripts/run-install.sh)>>
-  # - steps: << parameters.post-install >>
-  # - when:
-  #     condition:
-  #       equal: [ "true", -f yarn.lock ]
-  #     steps:
-  #       - save_cache:
-  #           key: << parameters.cache-key >>
-  #           paths:
-  #             - ~/.cache
-  # - unless:
-  #     condition:
-  #       equal: [ "true", -f yarn.lock ]
-  #     steps:
-  #       - save_cache:
-  #           key: << parameters.cache-key >>
-  #           paths:
-  #             - ~/.cache
-  #             - ~/.npm

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -38,8 +38,6 @@ steps:
       override-ci-command: << parameters.install-command >>
       app-dir: << parameters.working-directory >>
       pkg-manager: << parameters.pkg-manager >>
-      
-
 
   # - restore_cache:
   #     key: << parameters.cache-key >>

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -18,7 +18,7 @@ parameters:
   cache-key:
     description: Cache key used to cache the Cypress binary.
     type: string
-    default: 'cache-{{ arch }}-{{ checksum "package.json" }}'
+    default: 'cypress-cache-{{ arch }}-{{ checksum "package.json" }}'
   cache-path:
     description: |
         By default, this will cache the '~/.cache' directory so that the Cypress binary is cached. You can override this by providing your own cache path.
@@ -43,6 +43,7 @@ steps:
       override-ci-command: << parameters.install-command >>
       app-dir: << parameters.working-directory >>
       pkg-manager: << parameters.package-manager >>
+      include-branch-in-cache-key: false
   # run cypress
   - save_cache:
       name: Save Cypress Binary

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -24,6 +24,10 @@ parameters:
         By default, this will cache the '~/.cache' directory so that the Cypress binary is cached. You can override this by providing your own cache path.
     type: string
     default: '~/.cache'
+  node-cache-version:
+    type: string
+    default: 'v1'
+    description: Change the default node cache version if you need to clear the cache for any reason.
   working-directory:
     description: Directory containing package.json
     type: string
@@ -44,6 +48,7 @@ steps:
       app-dir: << parameters.working-directory >>
       pkg-manager: << parameters.package-manager >>
       include-branch-in-cache-key: false
+      cache-version: << parameters.node-cache-version >>
   # run cypress
   - save_cache:
       name: Save Cypress Binary

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -16,9 +16,14 @@ parameters:
     type: string
     default: ''
   cache-key:
-    description: Npm cache key used to cache Cypress and it's dependencies
+    description: Cache key used to cache the Cypress binary.
     type: string
     default: 'cache-{{ arch }}-{{ checksum "package.json" }}'
+  cache-path:
+    description: |
+        By default, this will cache the '~/.cache' directory so that the Cypress binary is cached. You can override this by providing your own cache path.
+    type: string
+    default: '~/.cache'
   working-directory:
     description: Directory containing package.json
     type: string
@@ -34,12 +39,13 @@ steps:
   - restore_cache:
       name: Restore Cypress cache
       key: << parameters.cache-key >>
-  - save_cache:
-      name: Save Cypress Binary
-      key: << parameters.cache-key >>
-      paths:
-        - ~/.cache
   - node/install-packages:
       override-ci-command: << parameters.install-command >>
       app-dir: << parameters.working-directory >>
       pkg-manager: << parameters.package-manager >>
+  # run cypress
+  - save_cache:
+      name: Save Cypress Binary
+      key: << parameters.cache-key >>
+      paths:
+        - << parameters.cache-path >>

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -29,10 +29,11 @@ steps:
   - run:
       name: "List Working Directory"
       command: ls -l
-  - node/install:
+  - node/install-packages:
       override-ci-command: << parameters.install-command >>
       app-dir: << parameters.working-directory >>
-  
+
+
   # - restore_cache:
   #     key: << parameters.cache-key >>
   # # we can install dependencies using "npm ci" or the


### PR DESCRIPTION
This adds support to lean into the `circleci/orb-tools@5` to handle dependency installation