### PR TITLE
docs: update CONTRIBUTING guide to include publishing steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,4 +87,6 @@ fix: a patch release
 4. Add the version number to the _Release Title_ and add release notes.
 5. Click the `Publish release` button.
 
-> For an example on how to publish the orb, you can view this [video on how to publish](https://www.youtube.com/watch?v=ImPE969yv08&list=PL9GgS3TcDh8yX7GeM8JheHsmGVWXlD-A_&index=4) > or you can view the [CircleCI Orb-Tools Publishing Documentation](https://circleci.com/developer/orbs/orb/circleci/orb-tools#jobs-publish)
+> For an example on how to publish the orb, view the 
+- [CircleCI Orb-Tools Publishing Documentation](https://circleci.com/docs/creating-orbs/)
+- [CircleCI Orb-Tools Publishing Params](https://circleci.com/developer/orbs/orb/circleci/orb-tools#jobs-publish)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,4 +81,10 @@ fix: a patch release
 
 ### Production
 
-<!-- TODO -->
+1. Merge changes into `master` and validate the CI passes all the necessary steps.
+2. Manually click the `Draft a new release` button in the GitHub UI.
+3. Choose an existing `tag` or create a new one and target the `master` branch.
+4. Add the version number to the _Release Title_ and add release notes.
+5. Click the `Publish release` button.
+
+> For an example on how to publish the orb, you can view this [video on how to publish](https://www.youtube.com/watch?v=ImPE969yv08&list=PL9GgS3TcDh8yX7GeM8JheHsmGVWXlD-A_&index=4) > or you can view the [CircleCI Orb-Tools Publishing Documentation](https://circleci.com/developer/orbs/orb/circleci/orb-tools#jobs-publish)


### PR DESCRIPTION
This PR updates the `CONTRIBUTING` guide with the necessary steps for publishing