### PR TITLE
fix: correct cypress/run tests default value for working-directory param

### DIFF
--- a/src/commands/run-tests.yml
+++ b/src/commands/run-tests.yml
@@ -5,7 +5,7 @@ parameters:
   working-directory:
     description: Directory containing package.json
     type: string
-    default: ""
+    default: "."
   start-command:
     description: Command used to start your local dev server for Cypress to tests against
     type: string


### PR DESCRIPTION
Closes #418 

The orb should automatically save video and screenshot artifacts to CircleCi. When users are not specifying a `working-directory` parameter, the default of `""` causes the artifact storage page to be an absolute path instead of a relative path, leading to missing artifacts in CircleCI.