### PR TITLE
chore: update circleci/browser-tools to latest version 

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -10,4 +10,4 @@ display:
 # if our orb requires other orbs, we can import them like this. Otherwise remove the "orbs" stanza.
 orbs:
   node: circleci/node@5
-  browser-tools: circleci/browser-tools@1
+  browser-tools: circleci/browser-tools@1.4.2


### PR DESCRIPTION
- Closes https://github.com/cypress-io/circleci-orb/issues/434

chore: update circleci/browser-tools to latest version which fixes problem installing chromedriver.  [CircleCi](https://github.com/CircleCI-Public/browser-tools-orb/issues/75#issuecomment-1641137783) fixed a problem where the endpoint CircleCi uses for downloading chrome driver changed for all versions >= 115.