### PR TITLE
feat: Update node defaults

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -8,7 +8,9 @@ filters: &filters
 
 jobs:
   install-and-persist:
-    executor: cypress/default
+    executor:
+      name: cypress/default
+      node-version: "18.18"
     steps:
       - cypress/install:
           working-directory: examples/angular-app

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -10,7 +10,7 @@ jobs:
   install-and-persist:
     executor:
       name: cypress/default
-      node-version: "18.18"
+      node-version: "20.6.0"
     steps:
       - cypress/install:
           working-directory: examples/angular-app

--- a/src/examples/node-version.yml
+++ b/src/examples/node-version.yml
@@ -1,0 +1,22 @@
+description: >
+  Run Cypress tests using the cypress/default executor with a specified node version.
+usage:
+  version: 2.1
+  orbs:
+    cypress: cypress-io/cypress@3
+jobs:
+  run-cypress-in-specified-node-version:
+    executor:
+      name: cypress/default
+      node-version: "20.6"
+    steps:
+      - cypress/install:
+          package-manager: "yarn"
+      - cypress/run-tests:
+          start-command: "npm run start:dev"
+          cypress-command: "npx cypress run"
+workflows:
+  use-my-orb:
+    jobs:
+      - run-cypress-in-specified-node-version:
+          name: Run Cypress in Node 20

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -3,7 +3,7 @@ description: >
 parameters:
   node-version:
     type: string
-    default: "16.16"
+    default: "18.15"
     description: >
       The version of Node to run your tests with.
 docker:

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -3,7 +3,7 @@ description: >
 parameters:
   node-version:
     type: string
-    default: "18.15"
+    default: "18.16.1"
     description: >
       The version of Node to run your tests with.
 docker:


### PR DESCRIPTION
This PR updates the default node version to `18.16` and adds documentation for how to change the default node version in the `cypress/default` executor.