### PR TITLE
feat: add pnpm support

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -45,7 +45,7 @@ parameters:
     default: ""
   package-manager:
     type: enum
-    enum: ["npm", "yarn", "yarn-berry"]
+    enum: ["npm", "yarn", "yarn-berry", "pnpm"]
     default: "npm"
     description: Select the default node package manager to use. NPM v5+ Required.
 


### PR DESCRIPTION
This change just adds pnpm to the this of allowed package managers.

Fixes: https://github.com/cypress-io/circleci-orb/issues/442