### PR TITLE
feat: add support for pnpm

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -45,7 +45,7 @@ parameters:
     default: ""
   package-manager:
     type: enum
-    enum: ["npm", "yarn", "yarn-berry"]
+    enum: ["npm", "yarn", "yarn-berry", "pnpm"]
     default: "npm"
     description: Select the default node package manager to use. NPM v5+ Required.
 

--- a/src/examples/pnpm.yml
+++ b/src/examples/pnpm.yml
@@ -11,3 +11,4 @@ usage:
         - cypress/run:
             package-manager: "pnpm"
             start-command: "pnpm start"
+            install-command: "pnpm install --frozen-lockfile"

--- a/src/examples/pnpm.yml
+++ b/src/examples/pnpm.yml
@@ -1,0 +1,13 @@
+description: >
+  Runs Cypress tests using pnpm.
+  Installs dependencies and caches NPM modules and the Cypress binary.
+usage:
+  version: 2.1
+  orbs:
+    cypress: cypress-io/cypress@3
+  workflows:
+    use-my-orb:
+      jobs:
+        - cypress/run:
+            package-manager: "pnpm"
+            start-command: "pnpm start"

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -49,7 +49,7 @@ parameters:
     default: ""
   package-manager:
     type: enum
-    enum: ["npm", "yarn", "yarn-berry"]
+    enum: ["npm", "yarn", "yarn-berry", "pnpm"]
     default: "npm"
     description: Select the default node package manager to use. NPM v5+ Required.
   start-command:


### PR DESCRIPTION
This adds support for pnpm as a package manager. 

Closes https://github.com/cypress-io/circleci-orb/issues/442

This is currently blocked by https://github.com/CircleCI-Public/node-orb/pull/199
