### PR TITLE
chore: update circleci browser tools orb to v1.4.6

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -10,4 +10,4 @@ display:
 # if our orb requires other orbs, we can import them like this. Otherwise remove the "orbs" stanza.
 orbs:
   node: circleci/node@5
-  browser-tools: circleci/browser-tools@1.4.5
+  browser-tools: circleci/browser-tools@1.4.6


### PR DESCRIPTION
This will fix chrome driver install issues:
"fix: chromedriver versions not installing by @ryanbourdais in #96" https://github.com/CircleCI-Public/browser-tools-orb/releases/tag/v1.4.6

Should fix #446