### PR TITLE
chore: set circleci browser tools orb to pull v1 with updates

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -10,4 +10,4 @@ display:
 # if our orb requires other orbs, we can import them like this. Otherwise remove the "orbs" stanza.
 orbs:
   node: circleci/node@5
-  browser-tools: circleci/browser-tools@1.4.5
+  browser-tools: circleci/browser-tools@1


### PR DESCRIPTION
Pin the version @1 so that non-breaking updates and fixes can be pulled in automatically as they arise.