### PR TITLE
fix: update version of circleci/browser-tools

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -10,4 +10,4 @@ display:
 # if our orb requires other orbs, we can import them like this. Otherwise remove the "orbs" stanza.
 orbs:
   node: circleci/node@5
-  browser-tools: circleci/browser-tools@1
+  browser-tools: circleci/browser-tools@1.4.6


### PR DESCRIPTION
Their is a bug with `circleci/browser-tools@1.4.5` with downloading the chrome-driver https://github.com/CircleCI-Public/browser-tools-orb/releases/tag/v1.4.6. Originally discovered in this PR https://github.com/cypress-io/circleci-orb/pull/452.  This PR bumps the version to `1.4.6` which fixes the issue