### PR TITLE
Fix: Add colon after cypress/run key

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ orbs:
 workflows:
   build:
     jobs:
-      - cypress/run # "run" job comes from "Cypress" orb
+      - cypress/run: # "run" job comes from "Cypress" orb
           start-command: 'npm run start'
 ```
 


### PR DESCRIPTION
### Summary:

- File changed: README.md
- Using version 3 of the orb

### Description:
- The [documentation](https://docs.cypress.io/guides/continuous-integration/circleci) showing how to configure the Cypress CircleCI Orb via the circleci/config.yml file does not include a required colon after the mapping key `cypress/run` in the example under the "Basic Setup" heading. Without a colon, the CircleCI build fails.
<img width="744" alt="Screenshot 2024-01-14 at 3 54 40 PM" src="https://github.com/cypress-io/circleci-orb/assets/130494366/bdf6d94e-a118-4293-95ad-94ca14657625">

- In the subsequent circleci/config.yml file illustrations for Parallelization and Additional Examples, a colon is included.
- By highlighting this inconsistency, I aim to clarify the proper orb setup that adheres to YAML syntax. This will make it easier for others to install, cache, and run Cypress tests in CircleCI, aligning with the documentation's recommendations.
- Below is the YAML configuration with the colon separating the key from its associated value.

```
version: 2.1
orbs:
  cypress: cypress-io/cypress@3
workflows:
  build:
    jobs:
      - cypress/run:
          start-command: 'npm run start'
```

