### PR TITLE
chore: update circleci browser tools orb to v1.4.8

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -10,4 +10,4 @@ display:
 # if our orb requires other orbs, we can import them like this. Otherwise remove the "orbs" stanza.
 orbs:
   node: circleci/node@5
-  browser-tools: circleci/browser-tools@1
+  browser-tools: circleci/browser-tools@1.4.8


### PR DESCRIPTION
This will fix chrome driver install issues:
fix download urls by using chrome supplied links by @DP19 in https://github.com/CircleCI-Public/browser-tools-orb/pull/109
https://github.com/CircleCI-Public/browser-tools-orb/releases/tag/v1.4.8

Fix #460