### PR TITLE
fix: bump browser tools to fix 404 on chrome install

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -10,4 +10,4 @@ display:
 # if our orb requires other orbs, we can import them like this. Otherwise remove the "orbs" stanza.
 orbs:
   node: circleci/node@5
-  browser-tools: circleci/browser-tools@1
+  browser-tools: circleci/browser-tools@1.4.8


### PR DESCRIPTION
Close https://github.com/cypress-io/circleci-orb/issues/460

A downstream fix was published in browser-tools-orb: https://github.com/CircleCI-Public/browser-tools-orb/releases/tag/v1.4.8 to address an issue where downloading the chrome browser results in a 404 and does not install.

Since orbs are immutable as noted in [this thread](https://github.com/cypress-io/circleci-orb/issues/460#issuecomment-1974810503), we need to explicitly set a version for our dependency orb and republish to get this fix. 

