### PR TITLE
ci(deps): update ct docker image to cypress/browsers:node-18.20.3

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -23,7 +23,7 @@ jobs:
             - project
   run-ct-tests-in-chrome:
     docker:
-      - image: cypress/browsers:node-16.18.1-chrome-109.0.5414.74-1-ff-109.0-edge-109.0.1518.52-1
+      - image: cypress/browsers:node-18.20.3-chrome-125.0.6422.141-1-ff-126.0.1-edge-125.0.2535.85-1
     parallelism: 2
     steps:
       - run: echo "This step assumes dependencies were installed using the cypress/install job"
@@ -34,7 +34,7 @@ jobs:
           cypress-command: "npx cypress run --component --parallel --record --group 2x-chrome --browser chrome"
   run-ct-tests-in-firefox:
     docker:
-      - image: cypress/browsers:node-16.18.1-chrome-109.0.5414.74-1-ff-109.0-edge-109.0.1518.52-1
+      - image: cypress/browsers:node-18.20.3-chrome-125.0.6422.141-1-ff-126.0.1-edge-125.0.2535.85-1
     parallelism: 2
     steps:
       - run: echo "This step assumes dependencies were installed using the cypress/install job"
@@ -45,7 +45,7 @@ jobs:
           cypress-command: "npx cypress run --component --parallel --record --group 2x-firefox --browser firefox"
   run-ct-tests-in-edge:
     docker:
-      - image: cypress/browsers:node-16.18.1-chrome-109.0.5414.74-1-ff-109.0-edge-109.0.1518.52-1
+      - image: cypress/browsers:node-18.20.3-chrome-125.0.6422.141-1-ff-126.0.1-edge-125.0.2535.85-1
     parallelism: 2
     steps:
       - run: echo "This step assumes dependencies were installed using the cypress/install job"


### PR DESCRIPTION
- closes https://github.com/cypress-io/circleci-orb/issues/448

## Issue

The CircleCI workflow [.circleci/test-deploy.yml](https://github.com/cypress-io/circleci-orb/blob/master/.circleci/test-deploy.yml) is configured to use the Docker container:

`cypress/browsers:node-16.18.1-chrome-109.0.5414.74-1-ff-109.0-edge-109.0.1518.52-1`

for component testing of [examples/angular-app](https://github.com/cypress-io/circleci-orb/tree/master/examples/angular-app).

Node.js `16` already reached [end-of-life](https://nodejs.org/en/blog/announcements/nodejs16-eol/) on Sep 11, 2023 and is no longer supported.

## Compatibility constraints

- ~~[examples/angular-app](https://github.com/cypress-io/circleci-orb/tree/master/examples/angular-app) is currently configured for Angular `15.1`~~
- [examples/angular-app](https://github.com/cypress-io/circleci-orb/tree/master/examples/angular-app) is currently configured for Angular `16.2.12`
- ~~[Angular - Version compatibility](https://angular.dev/reference/versions) shows Angular `15.1` compatible with Node.js 	`^14.20.0 || ^16.13.0 || ^18.10.0`~~
- [Angular - Version compatibility](https://angular.dev/reference/versions) shows Angular `16.2` compatible with Node.js 	`^16.14.0 || ^18.10.0`
- All later supported versions of Angular `17.x` - `18.x` overlap compatibility if Node.js `^18.19.1` is used
- For Firefox `124.0` and later, a minimum of [cypress@13.7.1](https://docs.cypress.io/guides/references/changelog#13-7-1) is needed. Edit: secured through PR https://github.com/cypress-io/circleci-orb/pull/472

## Change

Update the Docker container used for component testing in [.circleci/test-deploy.yml](https://github.com/cypress-io/circleci-orb/blob/master/.circleci/test-deploy.yml) from

- `cypress/browsers:node-16.18.1-chrome-109.0.5414.74-1-ff-109.0-edge-109.0.1518.52-1`

to

- `cypress/browsers:node-18.20.3-chrome-125.0.6422.141-1-ff-126.0.1-edge-125.0.2535.85-1`

This Cypress Docker image contains:

- Node.js `18.20.3`
- Chrome  `125.0.6422.141-1`
- Firefox `126.0.1`
- Edge    `125.0.2535.85-1`
