### PR TITLE
chore(deps): update config.yml to orb-tools 12.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 setup: true
 orbs:
-  orb-tools: circleci/orb-tools@11.6.1
+  orb-tools: circleci/orb-tools@12.1.0
   shellcheck: circleci/shellcheck@3.2.0
 
 filters: &filters


### PR DESCRIPTION
- This PR may allow issue https://github.com/cypress-io/circleci-orb/issues/476 to be closed.

## Issue

The CI workflow [.circleci/test-deploy.yml](https://github.com/cypress-io/circleci-orb/blob/master/.circleci/test-deploy.yml) shows in the logs https://app.circleci.com/pipelines/gh/cypress-io/circleci-orb/1945:

```text
Error calling workflow: 'test-deploy'
Error calling job: 'orb-tools/publish'
Missing required argument(s): orb_name, vcs_type
```

## References

- [`orb-tools` - Orb Quick Start Guide](https://circleci.com/developer/orbs/orb/circleci/orb-tools)

## Change

Update [.circleci/test-deploy.yml](https://github.com/cypress-io/circleci-orb/blob/master/.circleci/test-deploy.yml) to use [orb-tools@12.1.0](https://github.com/CircleCI-Public/orb-tools-orb/releases/tag/v12.1.0)