### PR TITLE
Revert "chore(deps): update dependency orb-tools to v12 (#469)"

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   cypress: cypress-io/cypress@dev:<<pipeline.git.revision>>
-  orb-tools: circleci/orb-tools@12.1.0
+  orb-tools: circleci/orb-tools@11.6.1
 filters: &filters
   tags:
     only: /.*/


### PR DESCRIPTION
- Closes https://github.com/cypress-io/circleci-orb/issues/476

## Issue

The CI workflow [.circleci/test-deploy.yml](https://github.com/cypress-io/circleci-orb/blob/master/.circleci/test-deploy.yml) shows in the logs https://app.circleci.com/pipelines/gh/cypress-io/circleci-orb/1945

```text
Error calling workflow: 'test-deploy'
Error calling job: 'orb-tools/publish'
Missing required argument(s): orb_name, vcs_type
```

- PR #469 has attempted an incomplete update to CircleCI `orb-tools` v12 without paying regard to the [Migration Guide](https://github.com/CircleCI-Public/orb-tools-orb/blob/master/MIGRATION.md)