### PR TITLE
ci(deps): update test-deploy to node 20.15.1 LTS

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -10,7 +10,7 @@ jobs:
   install-and-persist:
     executor:
       name: cypress/default
-      node-version: "20.6.0"
+      node-version: "20.15.1"
     steps:
       - cypress/install:
           working-directory: examples/angular-app
@@ -23,7 +23,7 @@ jobs:
             - project
   run-ct-tests-in-chrome:
     docker:
-      - image: cypress/browsers:node-18.20.3-chrome-125.0.6422.141-1-ff-126.0.1-edge-125.0.2535.85-1
+      - image: cypress/browsers:node-20.15.1-chrome-126.0.6478.126-1-ff-128.0-edge-126.0.2592.102-1
     parallelism: 2
     steps:
       - run: echo "This step assumes dependencies were installed using the cypress/install job"
@@ -34,7 +34,7 @@ jobs:
           cypress-command: "npx cypress run --component --parallel --record --group 2x-chrome --browser chrome"
   run-ct-tests-in-firefox:
     docker:
-      - image: cypress/browsers:node-18.20.3-chrome-125.0.6422.141-1-ff-126.0.1-edge-125.0.2535.85-1
+      - image: cypress/browsers:node-20.15.1-chrome-126.0.6478.126-1-ff-128.0-edge-126.0.2592.102-1
     parallelism: 2
     steps:
       - run: echo "This step assumes dependencies were installed using the cypress/install job"
@@ -45,7 +45,7 @@ jobs:
           cypress-command: "npx cypress run --component --parallel --record --group 2x-firefox --browser firefox"
   run-ct-tests-in-edge:
     docker:
-      - image: cypress/browsers:node-18.20.3-chrome-125.0.6422.141-1-ff-126.0.1-edge-125.0.2535.85-1
+      - image: cypress/browsers:node-20.15.1-chrome-126.0.6478.126-1-ff-128.0-edge-126.0.2592.102-1
     parallelism: 2
     steps:
       - run: echo "This step assumes dependencies were installed using the cypress/install job"


### PR DESCRIPTION
- closes https://github.com/cypress-io/circleci-orb/issues/481

## Issue

The workflow [.circleci/test-deploy.yml](https://github.com/cypress-io/circleci-orb/blob/master/.circleci/test-deploy.yml) is using mixed major versions of Node.js `18.x` and `20.x` (`18.20.3` & `20.6.0`).

https://github.com/cypress-io/circleci-orb/blob/cc4944de6aaa74cf9cdbbad422e1e8a2061218a8/.circleci/test-deploy.yml#L10-L13

https://github.com/cypress-io/circleci-orb/blob/cc4944de6aaa74cf9cdbbad422e1e8a2061218a8/.circleci/test-deploy.yml#L25-L26

## Compatibility constraints

- [examples/angular-app](https://github.com/cypress-io/circleci-orb/tree/master/examples/angular-app) is currently configured for Angular `17.3.2`
- [Angular - Version compatibility](https://angular.dev/reference/versions) shows Angular `17.3` compatible with Node.js 	`^18.13.0 || ^20.9.0`

This allows use of the Node.js `20.x` LTS version.

## Change

Update Node.js version usage in [.circleci/test-deploy.yml](https://github.com/cypress-io/circleci-orb/blob/master/.circleci/test-deploy.yml) to use Node.js LTS `20.15.1`

| Specification | Before                                                                                  | After                                                                                  |
| ------------- | --------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| executor      | `20.6.0`                                                                                | `20.15.1`                                                                              |
| Docker image  | `cypress/browsers:node-18.20.3-chrome-125.0.6422.141-1-ff-126.0.1-edge-125.0.2535.85-1` | `cypress/browsers:node-20.15.1-chrome-126.0.6478.126-1-ff-128.0-edge-126.0.2592.102-1` |
