### PR TITLE
docs: replace and fix edge example

### DIFF
--- a/src/examples/edge.yml
+++ b/src/examples/edge.yml
@@ -4,12 +4,19 @@ usage:
   version: 2.1
   orbs:
     cypress: cypress-io/cypress@3
-  executor:
-    docker:
-      image: cypress/browsers:node-18.14.1-chrome-111.0.5563.146-1-ff-111.0.1-edge-111.0.1661.54-1
+  executors:
+    cypress-browsers:
+      docker:
+        - image: cypress/browsers:node-20.17.0-chrome-129.0.6668.70-1-ff-130.0.1-edge-129.0.2792.52-1
+  jobs:
+    edge-test:
+      executor: cypress-browsers
+      steps:
+        - cypress/install
+        - cypress/run-tests:
+            start-command: "npm run start:dev"
+            cypress-command: 'npx cypress run --browser edge'
   workflows:
     use-my-orb:
       jobs:
-        - cypress/run:
-            start-command: "npm run start:dev"
-            cypress-command: "npx cypress run --browser edge"
+        - edge-test


### PR DESCRIPTION
- Closes https://github.com/cypress-io/circleci-orb/issues/488

## Issue

The Edge example in [src/examples/edge.yml](https://github.com/cypress-io/circleci-orb/blob/master/src/examples/edge.yml) fails with the message:

> Can't run because you've entered an invalid browser name.
>
> Browser: edge was not found on your system or is not supported by Cypress.

## Change

Replace the `usage` section in [src/examples/edge.yml](https://github.com/cypress-io/circleci-orb/blob/master/src/examples/edge.yml) with the following workflow code:

```yml
version: 2.1
orbs:
  cypress: cypress-io/cypress@3
executors:
  cypress-browsers:
    docker:
      - image: cypress/browsers:node-20.17.0-chrome-129.0.6668.70-1-ff-130.0.1-edge-129.0.2792.52-1
jobs:
  edge-test:
    executor: cypress-browsers
    steps:
      - cypress/install
      - cypress/run-tests:
          start-command: "npm run start:dev"
          cypress-command: 'npx cypress run --browser edge'
workflows:
  use-my-orb:
    jobs:
      - edge-test
```

- Use the commands
  - [cypress/install](https://circleci.com/developer/orbs/orb/cypress-io/cypress#commands-install)
  - [cypress/run-tests](https://circleci.com/developer/orbs/orb/cypress-io/cypress#commands-run-tests)

  instead of the job
  - [cypress/run](https://circleci.com/developer/orbs/orb/cypress-io/cypress#jobs-run) which is restricted to Electron, Chrome and Firefox

- Update the Cypress Docker image to
    `cypress/browsers:node-20.17.0-chrome-129.0.6668.70-1-ff-130.0.1-edge-129.0.2792.52-1`
