### PR TITLE
Allow skipping checkout in `install` and `run`

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -113,6 +113,14 @@ workflows:
           cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "examples/angular-app/package.json" }}
           cypress-command: "npx cypress run --component --parallel --record"
           parallelism: 3
+      - cypress/run:
+          filters: *filters
+          name: Verify skip-checkout
+          working-directory: examples/angular-app
+          cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "examples/angular-app/package.json" }}
+          cypress-command: "npx cypress run --component --parallel --record"
+          pre-steps:
+            - checkout
       - install-and-persist:
           filters: *filters
           name: Install & Persist
@@ -151,6 +159,7 @@ workflows:
             - Run CT Tests in Chrome
             - Run CT Tests in Firefox
             - Run CT Tests in Edge
+            - Verify skip-checkout
           context: circleci-orb-publishing
           filters:
             branches:

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -48,9 +48,16 @@ parameters:
     enum: ["npm", "yarn", "yarn-berry", "pnpm"]
     default: "npm"
     description: Select the default node package manager to use. NPM v5+ Required.
+  skip-checkout:
+    type: boolean
+    default: false
+    description: Allow skipping the `checkout` command
 
 steps:
-  - checkout
+  - unless:
+      condition: << parameters.skip-checkout >>
+      stepse:
+        - checkout
   - when:
       condition: << parameters.install-browsers >>
       steps:

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -73,6 +73,10 @@ parameters:
     default: "18.16.1" # keep in sync with executors/default.yml
     description: >
       The version of Node to run your tests with.
+  skip-checkout:
+    type: boolean
+    default: false
+    description: Whether to skip code checkout
 
 steps:
   - install:
@@ -85,6 +89,7 @@ steps:
       package-manager: << parameters.package-manager >>
       include-branch-in-node-cache-key: << parameters.include-branch-in-node-cache-key >>
       install-browsers: << parameters.install-browsers >>
+      skip-checkout: << parameters.skip-checkout >>
   - run-tests:
       working-directory: << parameters.working-directory >>
       start-command: << parameters.start-command >>


### PR DESCRIPTION
We use a custom checkout command and need to skip the default