### PR TITLE
fix: Fix the PNPM example test

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -67,7 +67,8 @@ steps:
       key: << parameters.cypress-cache-key >>
   - when:
       condition:
-        - equal: [ 'pnpm', << parameters.package-manager >> ]
+        and:
+          - equal: [ 'pnpm', << parameters.package-manager >> ]
       steps:
         - node/install:
             install-pnpm: true

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -65,6 +65,12 @@ steps:
   - restore_cache:
       name: Restore Cypress cache
       key: << parameters.cypress-cache-key >>
+  - when:
+      condition:
+        - equal: [ 'pnpm', << parameters.package-manager >> ]
+      steps:
+        - node/install:
+            install-pnpm: true
   - node/install-packages:
       override-ci-command: << parameters.install-command >>
       app-dir: << parameters.working-directory >>


### PR DESCRIPTION
Currently the **pnpm example** test is failing. This seems to be due to an old version of `pnpm` being present on the machine ([version 8 instead of version 9](https://app.circleci.com/pipelines/github/ramykl/circleci-orb/20/workflows/fd6a1923-37af-4016-807f-25ac2cf44fb6/jobs/81?invite=true#step-106-46_5)). I'm still a little unsure why this is the case...I would either expect pnpm not to be installed at all or for it to install the latest version as pnpm isn't packaged with node...maybe a cache hit?

After doing various testing https://github.com/ramykl/circleci-orb/pull/4 (sorry for the bad commit messages) it seems like the node orb doesn't install the package manager when using `node/install-packages`.

This will explicitly install the pnpm package manager through the node orb, which by default will install the latest version.