### PR TITLE
fix: CI Pnpm example lockfile incompatibility

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -86,6 +86,7 @@ workflows:
       - cypress/run:
           filters: *filters
           name: Pnpm Example
+          node-version: "22.11.0"
           working-directory: examples/pnpm-install
           cypress-cache-key: cypress-cache{{ arch }}-{{ checksum "examples/pnpm-install/package.json" }}
           post-install: "pnpm dlx cypress install"


### PR DESCRIPTION
- relates to issue https://github.com/cypress-io/circleci-orb/issues/493

## Issue

The `test-deploy` workflow in [.circleci/test-deploy.yml](https://github.com/cypress-io/circleci-orb/blob/master/.circleci/test-deploy.yml) fails running the job `name: Pnpm Example`, in the step "Installing PNPM packages", when triggered by tag creation, with the error message:

```text
 WARN  Ignoring not compatible lockfile at /home/circleci/project/examples/pnpm-install/pnpm-lock.yaml
node_modules/.pnpm                       |  WARN  Ignoring not compatible lockfile at /home/circleci/project/examples/pnpm-install/node_modules/.pnpm/lock.yaml
 ERR_PNPM_NO_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is present

Note that in CI environments this setting is true by default. If you still need to run install in such cases, use "pnpm install --no-frozen-lockfile"

Exited with code exit status 1
```

The job is running in the CircleCI Docker image `cimg/node:18.16.1-browsers` which has `pnpm@8.6.3` pre-installed.

[examples/pnpm-install/pnpm-lock.yaml](https://github.com/cypress-io/circleci-orb/blob/master/examples/pnpm-install/pnpm-lock.yaml) uses `lockfileVersion: '9.0'`. This requires `pnpm@9` and is incompatible with `pnpm@8`.  The command `pnpm install --frozen-lockfile`, from the [circleci/node](https://circleci.com/developer/orbs/orb/circleci/node) Orb, fails due to lockfile incompatibility.

## Change

As a workaround, add `node-version: '22.11.0'` to the job `name: Pnpm Example`. The CircleCI Docker image `cimg/node:22.11.0-browsers` has `pnpm@9.12.3` installed, which is compatible with [examples/pnpm-install/pnpm-lock.yaml](https://github.com/cypress-io/circleci-orb/blob/master/examples/pnpm-install/pnpm-lock.yaml).

## Note

- Issue https://github.com/cypress-io/circleci-orb/issues/451, which prevents this PR from performing a complete set of checks in CI.
