### PR TITLE
docs: fix orb pack instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ The repo provides a subset of the _orb-tools_ jobs and scripts that can be run l
 All CircleCI orbs are single YAML files, typically named `orb.yml`. However, for development, it is often easier to break the code up into more manageable chunks. The `circleci orb pack` command, a component of the [orb development kit](https://circleci.com/docs/orb-development-kit/), is used to "pack" or condense the seprate YAML files together into a single `orb.yml` file.
 
 ```bash
-circleci orb pack ./src
+circleci orb pack ./src > orb.yml
 ```
 
 ### Local Validating
@@ -98,6 +98,6 @@ fix: a patch release
     - Check `Set as the latest release` option.
     - Click the `Publish release` button.
 
-> For an example on how to publish the orb, view the 
+> For an example on how to publish the orb, view the
 - [CircleCI Orb-Tools Publishing Documentation](https://circleci.com/docs/creating-orbs/)
 - [CircleCI Orb-Tools Publishing Params](https://circleci.com/developer/orbs/orb/circleci/orb-tools#jobs-publish)


### PR DESCRIPTION
## Issue

The instructions in [CONTRIBUTING > Local Packing](https://github.com/cypress-io/circleci-orb/blob/master/CONTRIBUTING.md#local-packing) do not result in the generation of a file `orb.yml` which is needed for the command `circleci orb validate orb.yml`.

The CircleCI documentation [Orb packing](https://circleci.com/docs/orb-concepts/#orb-packing) quotes the example command that generates a file:

```shell
circleci orb pack <dir> > orb.yml
```

## Change

Correct the instructions in [CONTRIBUTING > Local Packing](https://github.com/cypress-io/circleci-orb/blob/master/CONTRIBUTING.md#local-packing) to read:

```shell
circleci orb pack ./src > orb.yml
```
