### PR TITLE
docs: fix local execute instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Assuming your `./circleci/config.yml` file appears similar to the one in this re
 #### CircleCI Local Linting
 
 ```bash
-circleci local execute --job orb-tools/lint
+circleci local execute orb-tools/lint
 ```
 
 #### YamlLint Local Linting
@@ -54,7 +54,7 @@ yamllint ./src
 #### CircleCI Local Shellcheck
 
 ```bash
-circleci local execute --job shellcheck/check
+circleci local execute shellcheck/check
 ```
 
 ### Local Review
@@ -64,10 +64,10 @@ The `review` job is a suite of Bash unit tests written using [bats-core](https:/
 #### CircleCI Local Review
 
 ```bash
-circleci local execute --job orb-tools/review
+circleci local execute orb-tools/review
 ```
 
-**Note**: You will _always_ see a failure at the end of this job when ran locally because the job contains a step to upload test results to CircleCI.com, which is _not_ supported in the local agent.
+**Note**: You will _always_ see a failure at the end of this job when run locally because the job contains a step to upload test results to CircleCI.com, which is _not_ supported in the local agent.
 
 ### Commits
 
@@ -98,6 +98,6 @@ fix: a patch release
     - Check `Set as the latest release` option.
     - Click the `Publish release` button.
 
-> For an example on how to publish the orb, view the 
+> For an example on how to publish the orb, view the
 - [CircleCI Orb-Tools Publishing Documentation](https://circleci.com/docs/creating-orbs/)
 - [CircleCI Orb-Tools Publishing Params](https://circleci.com/developer/orbs/orb/circleci/orb-tools#jobs-publish)


### PR DESCRIPTION
## Issue

The instructions in the [CONTRIBUTING](https://github.com/cypress-io/circleci-orb/blob/master/CONTRIBUTING.md#local-packing) document to execute a job locally do not work. For instance, in the section [CircleCI Local Review](https://github.com/cypress-io/circleci-orb/blob/master/CONTRIBUTING.md#circleci-local-review) the following command:

```shell
circleci local execute --job orb-tools/review
```

results in the error message:

> Error: unknown flag: --job

The help text is also shown:

```text
┃  circleci local execute                                                                                                ┃
┃                                                                                                                        ┃
┃  Usage:                                                                                                                ┃
┃         circleci local execute <job-name> [flags]
```

## Change

Correct the instructions in the [CONTRIBUTING](https://github.com/cypress-io/circleci-orb/blob/master/CONTRIBUTING.md#local-packing) document to remove the `--job` flag from commands using it. According to the help text, the `<job-name>` requires no flag to introduce it.
