### PR TITLE
update browsertools orb

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -10,4 +10,4 @@ display:
 # if our orb requires other orbs, we can import them like this. Otherwise remove the "orbs" stanza.
 orbs:
   node: circleci/node@6
-  browser-tools: circleci/browser-tools@1.4.8
+  browser-tools: circleci/browser-tools@1.5.1


### PR DESCRIPTION
An issue started occurring with the latest version of Firefox, that prevented successful downloading. 

The browser tools orb has since been updated, but this latest version needs to be reflected in this orbs source. 

There is more info the browser tools [related issue](https://github.com/CircleCI-Public/browser-tools-orb/issues/122)