### PR TITLE
feat: Enable configuring Docker `resource_class` for `run` job

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -129,6 +129,15 @@ workflows:
           cypress-command: "npx cypress run --component --parallel --record"
           pre-steps:
             - checkout
+      - cypress/run:
+          filters: *filters
+          name: Verify resource_class config works
+          working-directory: examples/angular-app
+          cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "examples/angular-app/package.json" }}
+          cypress-command: "npx cypress run --component --parallel --record"
+          resource_class: small
+          pre-steps:
+            - checkout
       - install-and-persist:
           filters: *filters
           name: Install & Persist
@@ -177,6 +186,7 @@ workflows:
             - Run CT Tests in Firefox
             - Run CT Tests in Edge
             - Verify skip-checkout
+            - Verify resource_class config works
           context: circleci-orb-publishing
       - orb-tools/publish:
           name: publish_prod
@@ -202,6 +212,7 @@ workflows:
             - Run CT Tests in Firefox
             - Run CT Tests in Edge
             - Verify skip-checkout
+            - Verify resource_class config works
           context: circleci-orb-publishing
           filters:
             branches:

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -6,6 +6,7 @@ executor:
   node-version: << parameters.node-version >>
 
 parallelism: << parameters.parallelism >>
+resource_class: << parameters.resource_class >>
 
 parameters:
   install-command:
@@ -77,6 +78,21 @@ parameters:
     type: boolean
     default: false
     description: Whether to skip code checkout
+  resource_class:
+    type: string
+    default: medium
+    enum:
+      - small
+      - medium
+      - medium+
+      - large
+      - xlarge
+      - 2xlarge
+      - 2xlarge+
+      - arm.medium
+      - arm.large
+      - arm.xlarge
+      - arm.2xlarge
 
 steps:
   - install:


### PR DESCRIPTION
- Add the option to pass through `resource_class` to the `run` job.
- Limit possible `resource_class` values to valid Docker resource classes

Closes #503 