### PR TITLE
docs: update Edge example to cypress/browsers:22.15.0

### DIFF
--- a/src/examples/edge.yml
+++ b/src/examples/edge.yml
@@ -7,7 +7,7 @@ usage:
   executors:
     cypress-browsers:
       docker:
-        - image: cypress/browsers:node-20.17.0-chrome-129.0.6668.70-1-ff-130.0.1-edge-129.0.2792.52-1
+        - image: cypress/browsers:22.15.0
   jobs:
     edge-test:
       executor: cypress-browsers


### PR DESCRIPTION
## Issue

The Edge browser version in the Cypress Docker image used in the [src/examples/edge.yml](https://github.com/cypress-io/circleci-orb/blob/master/src/examples/edge.yml)

`cypress/browsers:node-20.17.0-chrome-129.0.6668.70-1-ff-130.0.1-edge-129.0.2792.52-1`

is no longer [supported by Cypress](https://docs.cypress.io/app/references/launching-browsers#Browser-versions-supported).

The current major version of the Microsoft Edge browser in the [stable release channel](https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel) is `135`. Cypress therefore currently supports versions `133`, `134` and `135`, which excludes version `129`.

## Change

Update the [src/examples/edge.yml](https://github.com/cypress-io/circleci-orb/blob/master/src/examples/edge.yml) to use the Cypress Docker image:

`cypress/browsers:22.15.0`

which currently corresponds to `cypress/browsers:latest` and contains the supported browser version Microsoft Edge `135.x`.

## Note

- Due to issue https://github.com/cypress-io/circleci-orb/issues/498 this part of the example being changed is not actually published to the CircleCI website on https://circleci.com/developer/orbs/orb/cypress-io/cypress#usage-edge. It is only viewable if a user looks at the source code. Unfortunately the CircleCI pack process chops it off.
