### PR TITLE
feat: update default node.js to 22.15.0

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -9,5 +9,5 @@ display:
 
 # if our orb requires other orbs, we can import them like this. Otherwise remove the "orbs" stanza.
 orbs:
-  node: circleci/node@6
-  browser-tools: circleci/browser-tools@1.5.1
+  node: circleci/node@7
+  browser-tools: circleci/browser-tools@1.5.3

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -3,7 +3,7 @@ description: >
 parameters:
   node-version:
     type: string
-    default: "18.16.1" # keep in sync with jobs/run.yml
+    default: "22.15.0" # keep in sync with jobs/run.yml
     description: >
       The version of Node to run your tests with.
 docker:

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -70,7 +70,7 @@ parameters:
       (requires `parallel` and `record` flags in your `cypress-command`)
   node-version:
     type: string
-    default: "18.16.1" # keep in sync with executors/default.yml
+    default: "22.15.0" # keep in sync with executors/default.yml
     description: >
       The version of Node to run your tests with.
   skip-checkout:


### PR DESCRIPTION
BREAKING CHANGE:

- closes https://github.com/cypress-io/circleci-orb/issues/518

## Issue

Orb defaults to Node.js `18.16.1`

https://github.com/cypress-io/circleci-orb/blob/0292fa38d0a16ba15d982a870be31af43e6825af/src/executors/default.yml#L6

Node.js 18.x reaches [End-of-Life](https://github.com/nodejs/release#release-schedule) in a few days on Apr 30, 2025.

## Change

- Update the default Node.js from `18.16.1` to `22.15.0` from the [Active LTS Node.js](https://github.com/nodejs/release#release-schedule) release line.
- Update CircleCI Orb usage
    - [circleci/node](https://circleci.com/developer/orbs/orb/circleci/node) from 6 to 7
    - [circleci/browser-tools](https://circleci.com/developer/orbs/orb/circleci/browser-tools) from `1.5.1` to `1.5.3`