### PR TITLE
fix: update documentation and examples to orb v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ A typical project can have:
 ```yaml
 version: 2.1
 orbs:
-  # "cypress-io/cypress@3" installs the latest published
+  # "cypress-io/cypress@4" installs the latest published
   # version "s.x.y" of the orb. We recommend you then use
-  # the strict explicit version "cypress-io/cypress@3.x.y"
+  # the strict explicit version "cypress-io/cypress@4.x.y"
   # to lock the version and prevent unexpected CI changes
-  cypress: cypress-io/cypress@3
+  cypress: cypress-io/cypress@4
 workflows:
   build:
     jobs:
@@ -66,7 +66,7 @@ may have:
 ```yaml
 version: 2.1
 orbs:
-  cypress: cypress-io/cypress@3
+  cypress: cypress-io/cypress@4
 workflows:
   build:
     jobs:
@@ -135,7 +135,7 @@ A single Docker container used to run Cypress tests. This default executor exten
 ```yaml
 version: 2.1
 orbs:
-  cypress: cypress-io/cypress@3
+  cypress: cypress-io/cypress@4
 executor: cypress/default
 jobs:
   - cypress/run:
@@ -146,7 +146,7 @@ You can also use your own executor by passing in your own Docker image. See the 
 ```yaml
 version: 2.1
 orbs:
-  cypress: cypress-io/cypress@3
+  cypress: cypress-io/cypress@4
 executor:
   docker:
     image: cypress/browsers:22.15.0 # your Docker image here
@@ -161,7 +161,7 @@ jobs:
 ```yaml
 version: 2.1
 orbs:
-  cypress: cypress-io/cypress@3
+  cypress: cypress-io/cypress@4
 jobs:
   install:
     executor: cypress/default
@@ -199,7 +199,7 @@ Cypress orb is _versioned_ so you can be sure that the configuration will _not_ 
 
 You can find all changes and published orb versions for Cypress orb at [cypress-io/circleci-orb/releases](https://github.com/cypress-io/circleci-orb/releases).
 
-We are using `cypress-io/cypress@3` version in our examples, so you get the latest published orb version 3.x.x. But we recommend locking it down to an exact version to prevent unexpected changes from suddenly breaking your builds.
+We are using `cypress-io/cypress@4` version in our examples, so you get the latest published orb version `4.x.x`. But we recommend locking it down to an exact version to prevent unexpected changes from suddenly breaking your builds.
 
 ### License
 

--- a/src/examples/browser.yml
+++ b/src/examples/browser.yml
@@ -4,7 +4,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@3
+    cypress: cypress-io/cypress@4
   workflows:
     use-my-orb:
       jobs:

--- a/src/examples/caching.yml
+++ b/src/examples/caching.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@3
+    cypress: cypress-io/cypress@4
   workflows:
     use-my-orb:
       jobs:

--- a/src/examples/commands.yml
+++ b/src/examples/commands.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@3
+    cypress: cypress-io/cypress@4
   jobs:
     install-and-persist:
       executor: cypress/default

--- a/src/examples/component.yml
+++ b/src/examples/component.yml
@@ -4,7 +4,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@3
+    cypress: cypress-io/cypress@4
   workflows:
     use-my-orb:
       jobs:

--- a/src/examples/custom-install.yml
+++ b/src/examples/custom-install.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@3
+    cypress: cypress-io/cypress@4
   workflows:
     use-my-orb:
       jobs:

--- a/src/examples/edge.yml
+++ b/src/examples/edge.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@3
+    cypress: cypress-io/cypress@4
   executors:
     cypress-browsers:
       docker:

--- a/src/examples/mono-repo.yml
+++ b/src/examples/mono-repo.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@3
+    cypress: cypress-io/cypress@4
   workflows:
     use-my-orb:
       jobs:

--- a/src/examples/node-version.yml
+++ b/src/examples/node-version.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@3
+    cypress: cypress-io/cypress@4
   jobs:
     run-cypress-in-specified-node-version:
       executor:

--- a/src/examples/pnpm.yml
+++ b/src/examples/pnpm.yml
@@ -4,7 +4,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@3
+    cypress: cypress-io/cypress@4
   workflows:
     use-my-orb:
       jobs:

--- a/src/examples/recording.yml
+++ b/src/examples/recording.yml
@@ -4,7 +4,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@3
+    cypress: cypress-io/cypress@4
   workflows:
     use-my-orb:
       jobs:

--- a/src/examples/run.yml
+++ b/src/examples/run.yml
@@ -4,7 +4,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@3
+    cypress: cypress-io/cypress@4
   workflows:
     use-my-orb:
       jobs:

--- a/src/examples/wait-on.yml
+++ b/src/examples/wait-on.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@3
+    cypress: cypress-io/cypress@4
   workflows:
     use-my-orb:
       jobs:

--- a/src/examples/yarn.yml
+++ b/src/examples/yarn.yml
@@ -4,7 +4,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@3
+    cypress: cypress-io/cypress@4
   workflows:
     use-my-orb:
       jobs:


### PR DESCRIPTION
## Situation

- The [README](https://github.com/cypress-io/circleci-orb/blob/master/README.md) document shows the use of `cypress-io/cypress@3` although https://circleci.com/developer/orbs/orb/cypress-io/cypress is showing `cypress-io/cypress@4.0.0`

- Examples on https://circleci.com/developer/orbs/orb/cypress-io/cypress such as https://circleci.com/developer/orbs/orb/cypress-io/cypress#usage-browser still show `cypress-io/cypress@3`


## Change

- Update the text of the [README](https://github.com/cypress-io/circleci-orb/blob/master/README.md) to refer to `cypress-io/cypress@4`

- Update examples in [src/examples](https://github.com/cypress-io/circleci-orb/tree/master/src/examples) to use `cypress-io/cypress@4`
