### PR TITLE
test: enable angular e2e recording

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -112,7 +112,7 @@ workflows:
           working-directory: examples/angular-app
           cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "examples/angular-app/package.json" }}
           start-command: "npm run start"
-          cypress-command: "npx wait-on@latest http://localhost:4200 && npx cypress run --browser chrome"
+          cypress-command: "npx wait-on@latest http://localhost:4200 && npx cypress run --record --browser chrome"
           install-browsers: true
       - cypress/run:
           filters: *filters


### PR DESCRIPTION
- alternative to https://github.com/cypress-io/circleci-orb/pull/522

## Situation

The [.circleci/test-deploy.yml](https://github.com/cypress-io/circleci-orb/blob/master/.circleci/test-deploy.yml) pipeline job "Angular Application" causes a warning:

```text
This project has been configured to record runs on our Cypress Cloud.

It currently has the projectId: mx9dpd

You also provided your Record Key, but you did not pass the --record flag.

This run will not be recorded.

If you meant to have this run recorded please additionally pass this flag:

  $ cypress run --record

If you don't want to record these runs, you can silence this warning:

  $ cypress run --record false

https://on.cypress.io/recording-project-runs
```

- Feedback in https://github.com/cypress-io/circleci-orb/pull/522 states that the option `--record false` suggested by the warning message is invalid and should not be used.

## Change

Add `--record` to the [.circleci/test-deploy.yml](https://github.com/cypress-io/circleci-orb/blob/master/.circleci/test-deploy.yml) pipeline job "Angular Application" to enable recording the E2E test, together with the existing enabled recording of CT tests.