### PR TITLE
chore(deps): update circleci/browser-tools to 2.1.1

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -7,7 +7,6 @@ display:
   home_url: "https://cypress.io"
   source_url: "https://github.com/cypress-io/circleci-orb"
 
-# if our orb requires other orbs, we can import them like this. Otherwise remove the "orbs" stanza.
 orbs:
   node: circleci/node@7
-  browser-tools: circleci/browser-tools@1.5.3
+  browser-tools: circleci/browser-tools@2.1.1

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -61,7 +61,7 @@ steps:
   - when:
       condition: << parameters.install-browsers >>
       steps:
-        - browser-tools/install-browser-tools
+        - browser-tools/install_browser_tools
   - restore_cache:
       name: Restore Cypress cache
       key: << parameters.cypress-cache-key >>

--- a/src/examples/browser.yml
+++ b/src/examples/browser.yml
@@ -1,6 +1,5 @@
 description: >
-  Run Cypress tests using specified browser. The CircleCI Browser Tools orb at https://circleci.com/developer/orbs/orb/circleci/browser-tools#commands-install-browser-tools
-  currently supports Chrome & Firefox. See https://circleci.com/developer/orbs/orb/cypress-io/cypress#usage-edge, for Microsoft Edge support.
+  Run Cypress tests using specified browser. `install_browsers: true` installs the default browsers Chrome and Firefox from the CircleCI Browser Tools orb at https://circleci.com/developer/orbs/orb/circleci/browser-tools#commands-install_browser_tools. See https://circleci.com/developer/orbs/orb/cypress-io/cypress#usage-edge, for current Microsoft Edge support.
 usage:
   version: 2.1
   orbs:


### PR DESCRIPTION
- supports resolution of issue https://github.com/cypress-io/circleci-orb/issues/528
- partially replaces PR https://github.com/cypress-io/circleci-orb/pull/530

## Situation

- Issue https://github.com/cypress-io/circleci-orb/issues/528 proposes to support Chrome for Testing and Edge browsers through `v2` of the CircleCI Orb [circleci/browser-tools](https://circleci.com/developer/orbs/orb/circleci/browser-tools)

- PR https://github.com/cypress-io/circleci-orb/pull/530 has attempted to implement this proposal, however there are multiple failures in the PR

- [circleci/browser-tools@2.1.1](https://github.com/CircleCI-Public/browser-tools-orb/releases/tag/v2.1.1) is the minimum version which correctly supports Chrome for Testing in addition to Edge

- [circleci/browser-tools@2.0.0](https://github.com/CircleCI-Public/browser-tools-orb/releases/tag/v2.0.0) included the breaking change of making all commands snake case (using underscores) replacing kebab case (using hyphens).

## Change

In a first step, update the `cypress-io/circleci-orb` to use [circleci/browser-tools@2.1.1](https://github.com/CircleCI-Public/browser-tools-orb/releases/tag/v2.1.1) without any changes to Edge, and without attempting to add Chrome for Testing.

Change usage of:

- `browser-tools/install-browsers-tools` to [browser-tools/install_browsers_tools](https://circleci.com/developer/orbs/orb/circleci/browser-tools#commands-install_browser_tools) (snake case)

- Similarly, change bookmark usage to https://circleci.com/developer/orbs/orb/circleci/browser-tools#commands-install_browser_tools

The exposed boolean parameter `install-browsers` of the following job and command is left unchanged in kebab case, avoiding producing a breaking change for Cypress Orb users:

  - [cypress/run](https://circleci.com/developer/orbs/orb/cypress-io/cypress#jobs-run) (job)
  - [cypress/install](https://circleci.com/developer/orbs/orb/cypress-io/cypress#commands-install) (command)

In follow-on PRs, Edge can be migrated from relying on the Cypress Docker image [cypress/browsers](https://github.com/cypress-io/cypress-docker-images/tree/master/browsers) to instead use Edge installed with [circleci/browser-tools](https://circleci.com/developer/orbs/orb/circleci/browser-tools) and Chrome for Testing can be added.
