### PR TITLE
feat: install-browsers: true installs edge

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -44,8 +44,8 @@ jobs:
           working-directory: examples/angular-app
           cypress-command: "npx cypress run --component --parallel --record --group 2x-firefox --browser firefox"
   run-ct-tests-in-edge:
-    docker:
-      - image: cypress/browsers:22.16.0
+    executor:
+      name: cypress/default
     parallelism: 2
     steps:
       - run: echo "This step assumes dependencies were installed using the cypress/install job"

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -7,7 +7,6 @@ display:
   home_url: "https://cypress.io"
   source_url: "https://github.com/cypress-io/circleci-orb"
 
-# if our orb requires other orbs, we can import them like this. Otherwise remove the "orbs" stanza.
 orbs:
   node: circleci/node@7
-  browser-tools: circleci/browser-tools@1.5.3
+  browser-tools: circleci/browser-tools@2.1.1

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -61,7 +61,8 @@ steps:
   - when:
       condition: << parameters.install-browsers >>
       steps:
-        - browser-tools/install_browser_tools
+        - browser-tools/install_browser_tools:
+            install_chromedriver: false
   - restore_cache:
       name: Restore Cypress cache
       key: << parameters.cypress-cache-key >>

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -61,7 +61,7 @@ steps:
   - when:
       condition: << parameters.install-browsers >>
       steps:
-        - browser-tools/install-browser-tools
+        - browser-tools/install_browser_tools
   - restore_cache:
       name: Restore Cypress cache
       key: << parameters.cypress-cache-key >>

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -16,8 +16,8 @@ parameters:
     description: |
       Cypress runs by default in the Electron browser. Use this flag to install additional browsers to run your tests in.
       This is only needed if you are passing the `--browser` flag in your `cypress-command`.
-      This parameter leverages the `circleci/browser-tools` orb and includes Chrome and FireFox.
-      If you need additional browser support you can set this to false and use an executor with a docker image
+      This parameter leverages the `circleci/browser-tools` orb and includes Chrome, Edge and Firefox.
+      If you need additional browser support you can set this to false and use an executor with a Docker image
       that includes the browsers of your choosing. See https://hub.docker.com/r/cypress/browsers/tags
     type: boolean
     default: false
@@ -63,6 +63,7 @@ steps:
       steps:
         - browser-tools/install_browser_tools:
             install_chromedriver: false
+            install_edge: true
   - restore_cache:
       name: Restore Cypress cache
       key: << parameters.cypress-cache-key >>

--- a/src/examples/browser.yml
+++ b/src/examples/browser.yml
@@ -1,6 +1,5 @@
 description: >
-  Run Cypress tests using specified browser. The CircleCI Browser Tools orb at https://circleci.com/developer/orbs/orb/circleci/browser-tools#commands-install-browser-tools
-  currently supports Chrome & Firefox. See https://circleci.com/developer/orbs/orb/cypress-io/cypress#usage-edge, for Microsoft Edge support.
+  Run Cypress tests using specified browser. `install_browsers: true` installs the default browsers Chrome and Firefox from the CircleCI Browser Tools orb at https://circleci.com/developer/orbs/orb/circleci/browser-tools#commands-install_browser_tools. See https://circleci.com/developer/orbs/orb/cypress-io/cypress#usage-edge, for current Microsoft Edge support.
 usage:
   version: 2.1
   orbs:

--- a/src/examples/browser.yml
+++ b/src/examples/browser.yml
@@ -1,5 +1,5 @@
 description: >
-  Run Cypress tests using specified browser. `install_browsers: true` installs the default browsers Chrome and Firefox from the CircleCI Browser Tools orb at https://circleci.com/developer/orbs/orb/circleci/browser-tools#commands-install_browser_tools. See https://circleci.com/developer/orbs/orb/cypress-io/cypress#usage-edge, for current Microsoft Edge support.
+  Run Cypress tests using specified browser. `install_browsers: true` installs the default browsers Chrome and Firefox, and the optional browser Edge from the CircleCI Browser Tools orb at https://circleci.com/developer/orbs/orb/circleci/browser-tools#commands-install_browser_tools.
 usage:
   version: 2.1
   orbs:

--- a/src/examples/edge.yml
+++ b/src/examples/edge.yml
@@ -4,19 +4,10 @@ usage:
   version: 2.1
   orbs:
     cypress: cypress-io/cypress@4
-  executors:
-    cypress-browsers:
-      docker:
-        - image: cypress/browsers:22.15.0
-  jobs:
-    edge-test:
-      executor: cypress-browsers
-      steps:
-        - cypress/install
-        - cypress/run-tests:
-            start-command: "npm run start:dev"
-            cypress-command: 'npx cypress run --browser edge'
   workflows:
     use-my-orb:
       jobs:
-        - edge-test
+        - cypress/run:
+            start-command: "npm run start:dev"
+            cypress-command: "npx cypress run --browser edge"
+            install-browsers: true

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -23,7 +23,7 @@ parameters:
     description: |
       Cypress runs by default in the Electron browser. Use this flag to install additional browsers to run your tests in.
       This is only needed if you are passing the `--browser` flag in your `cypress-command`.
-      This parameter leverages the `circleci/browser-tools` orb and includes Chrome and FireFox.
+      This parameter leverages the `circleci/browser-tools` orb and includes Chrome, Edge and Firefox.
       If you need additional browser support you can set this to false and use an executor with a docker image
       that includes the browsers of your choosing. See https://hub.docker.com/r/cypress/browsers/tags
     type: boolean


### PR DESCRIPTION
- supports resolution of issue https://github.com/cypress-io/circleci-orb/issues/528
- partially replaces PR https://github.com/cypress-io/circleci-orb/pull/530
- resolves https://github.com/cypress-io/circleci-orb/issues/498

## Situation

- Issue https://github.com/cypress-io/circleci-orb/issues/528 proposes to support Chrome for Testing and Edge browsers through `v2` of the CircleCI Orb [circleci/browser-tools](https://circleci.com/developer/orbs/orb/circleci/browser-tools)

- PR https://github.com/cypress-io/circleci-orb/pull/530 has attempted to implement this proposal, however there are multiple failures in the PR

- PR https://github.com/cypress-io/circleci-orb/pull/531 is planned to allow Edge to be installed from [circleci/browser-tools](https://github.com/CircleCI-Public/browser-tools-orb/)

## Change

- Add `install_edge: true` to [src/commands/install.yml](https://github.com/cypress-io/circleci-orb/blob/master/src/commands/install.yml) so that the command `cypress/install-browsers: true` installs Edge in addition to Chrome and Firefox.

- Update [src/examples/edge.yml](https://github.com/cypress-io/circleci-orb/blob/master/src/examples/edge.yml) to use Edge from [circleci/browser-tools](https://circleci.com/developer/orbs/orb/circleci/browser-tools) instead of from the Cypress Docker image `cypress/browsers`.

- In [.circleci/test-deploy.yml](https://github.com/cypress-io/circleci-orb/blob/master/.circleci/test-deploy.yml)
  - Convert job `run-ct-tests-in-edge` to run in the orb's `cypress/default` instead of in the Docker image `cypress/browsers`

This means that the parameter `install-browsers: true` additionally installs the Edge browser in:

  - [cypress/run](https://circleci.com/developer/orbs/orb/cypress-io/cypress#jobs-run) (job)
  - [cypress/install](https://circleci.com/developer/orbs/orb/cypress-io/cypress#commands-install) (command)