### PR TITLE
feat: use CircleCI Chrome for Testing and Edge

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,6 +1,7 @@
 version: 2.1
 orbs:
   orb-tools: circleci/orb-tools@12.3.1
+  browser-tools: circleci/browser-tools@2.1.1
   # The orb will be injected here by the "continue" job.
 filters: &filters
   tags:
@@ -32,6 +33,18 @@ jobs:
       - cypress/run-tests:
           working-directory: examples/angular-app
           cypress-command: "npx cypress run --component --parallel --record --group 2x-chrome --browser chrome"
+  run-ct-tests-in-chrome-for-testing:
+    executor:
+      name: cypress/default
+    parallelism: 2
+    steps:
+      - run: echo "This step assumes dependencies were installed using the cypress/install job"
+      - attach_workspace:
+          at: ~/
+      - browser-tools/install_chrome_for_testing
+      - cypress/run-tests:
+          working-directory: examples/angular-app
+          cypress-command: "npx cypress run --component --parallel --record --group 2x-edge --browser chrome-for-testing"
   run-ct-tests-in-firefox:
     docker:
       - image: cypress/browsers:22.16.0
@@ -44,13 +57,14 @@ jobs:
           working-directory: examples/angular-app
           cypress-command: "npx cypress run --component --parallel --record --group 2x-firefox --browser firefox"
   run-ct-tests-in-edge:
-    docker:
-      - image: cypress/browsers:22.16.0
+    executor:
+      name: cypress/default
     parallelism: 2
     steps:
       - run: echo "This step assumes dependencies were installed using the cypress/install job"
       - attach_workspace:
           at: ~/
+      - browser-tools/install_edge
       - cypress/run-tests:
           working-directory: examples/angular-app
           cypress-command: "npx cypress run --component --parallel --record --group 2x-edge --browser edge"
@@ -146,6 +160,11 @@ workflows:
           name: Run CT Tests in Chrome
           requires:
             - Install & Persist
+      - run-ct-tests-in-chrome-for-testing:
+          filters: *filters
+          name: Run CT Tests in Chrome for Testing
+          requires:
+            - Install & Persist
       - run-ct-tests-in-firefox:
           filters: *filters
           name: Run CT Tests in Firefox
@@ -183,6 +202,7 @@ workflows:
             - Run CT in Parallel
             - Install & Persist
             - Run CT Tests in Chrome
+            - Run CT Tests in Chrome for Testing
             - Run CT Tests in Firefox
             - Run CT Tests in Edge
             - Verify skip-checkout
@@ -209,6 +229,7 @@ workflows:
             - Run CT in Parallel
             - Install & Persist
             - Run CT Tests in Chrome
+            - Run CT Tests in Chrome for Testing
             - Run CT Tests in Firefox
             - Run CT Tests in Edge
             - Verify skip-checkout

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -16,8 +16,8 @@ parameters:
     description: |
       Cypress runs by default in the Electron browser. Use this flag to install additional browsers to run your tests in.
       This is only needed if you are passing the `--browser` flag in your `cypress-command`.
-      This parameter leverages the `circleci/browser-tools` orb and includes Chrome and FireFox.
-      If you need additional browser support you can set this to false and use an executor with a docker image
+      This parameter leverages the `circleci/browser-tools` orb and includes Chrome, Chrome for Testing, Edge, Firefox and the geckodriver.
+      If you need additional browser support you can set this to false and use an executor with a Docker image
       that includes the browsers of your choosing. See https://hub.docker.com/r/cypress/browsers/tags
     type: boolean
     default: false
@@ -63,6 +63,8 @@ steps:
       steps:
         - browser-tools/install_browser_tools:
             install_chromedriver: false
+            install_chrome_for_testing: true
+            install_edge: true
   - restore_cache:
       name: Restore Cypress cache
       key: << parameters.cypress-cache-key >>

--- a/src/examples/browser.yml
+++ b/src/examples/browser.yml
@@ -1,5 +1,5 @@
 description: >
-  Run Cypress tests using specified browser. `install_browsers: true` installs the default browsers Chrome and Firefox from the CircleCI Browser Tools orb at https://circleci.com/developer/orbs/orb/circleci/browser-tools#commands-install_browser_tools. See https://circleci.com/developer/orbs/orb/cypress-io/cypress#usage-edge, for current Microsoft Edge support.
+  Run Cypress tests using specified browser. `install_browsers: true` installs the default browsers Chrome and Firefox with the geckodriver, and the optional browsers Chrome for Testing and Edge from the CircleCI Browser Tools orb at https://circleci.com/developer/orbs/orb/circleci/browser-tools#commands-install_browser_tools.
 usage:
   version: 2.1
   orbs:

--- a/src/examples/edge.yml
+++ b/src/examples/edge.yml
@@ -4,19 +4,10 @@ usage:
   version: 2.1
   orbs:
     cypress: cypress-io/cypress@4
-  executors:
-    cypress-browsers:
-      docker:
-        - image: cypress/browsers:22.15.0
-  jobs:
-    edge-test:
-      executor: cypress-browsers
-      steps:
-        - cypress/install
-        - cypress/run-tests:
-            start-command: "npm run start:dev"
-            cypress-command: 'npx cypress run --browser edge'
   workflows:
     use-my-orb:
       jobs:
-        - edge-test
+        - cypress/run:
+            start-command: "npm run start:dev"
+            cypress-command: "npx cypress run --browser edge"
+            install-browsers: true

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -23,7 +23,7 @@ parameters:
     description: |
       Cypress runs by default in the Electron browser. Use this flag to install additional browsers to run your tests in.
       This is only needed if you are passing the `--browser` flag in your `cypress-command`.
-      This parameter leverages the `circleci/browser-tools` orb and includes Chrome and FireFox.
+      This parameter leverages the `circleci/browser-tools` orb and includes Chrome, Chrome for Testing, Edge, Firefox and the geckodriver.
       If you need additional browser support you can set this to false and use an executor with a docker image
       that includes the browsers of your choosing. See https://hub.docker.com/r/cypress/browsers/tags
     type: boolean


### PR DESCRIPTION
- resolves https://github.com/cypress-io/circleci-orb/issues/528
- closes https://github.com/cypress-io/circleci-orb/pull/530 by replacing it

## Situation

- Issue https://github.com/cypress-io/circleci-orb/issues/528 proposes to support Chrome for Testing and Edge browsers through `v2` of the CircleCI Orb [circleci/browser-tools](https://circleci.com/developer/orbs/orb/circleci/browser-tools)

- PR https://github.com/cypress-io/circleci-orb/pull/530 has attempted to implement this proposal, however there are multiple failures in the PR

## Change

- In [.circleci/test-deploy.yml](https://github.com/cypress-io/circleci-orb/blob/master/.circleci/test-deploy.yml)
  - Change Edge tests in the job `run-ct-tests-in-edge` to run in the orb's `cypress/default` executor (instead of running in `cypress/browsers:22.16.0`)
  - Add job `run-ct-tests-in-chrome-for-testing` to run also in the orb's `cypress/default` executor

- In [src/commands/install.yml](https://github.com/cypress-io/circleci-orb/blob/master/src/commands/install.yml) add Chrome for Testing and Edge, so that the command `cypress/install-browsers: true` used in the job [cypress/run](https://circleci.com/developer/orbs/orb/cypress-io/cypress#jobs-run) or in the command [cypress/install](https://circleci.com/developer/orbs/orb/cypress-io/cypress#commands-install) installs these browsers in addition to Chrome, Firefox and the geckodriver.

- Convert the [src/examples/edge.yml](https://github.com/cypress-io/circleci-orb/blob/master/src/examples/edge.yml) to show `install-browsers: true` to test against Edge.
