### PR TITLE
test: correct chrome for testing record group

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -44,7 +44,7 @@ jobs:
       - browser-tools/install_chrome_for_testing
       - cypress/run-tests:
           working-directory: examples/angular-app
-          cypress-command: "npx cypress run --component --parallel --record --group 2x-edge --browser chrome-for-testing"
+          cypress-command: "npx cypress run --component --parallel --record --group 2x-chrome-for-testing --browser chrome-for-testing"
   run-ct-tests-in-firefox:
     docker:
       - image: cypress/browsers:22.16.0


### PR DESCRIPTION
## Situation

The newly-added job `run-ct-tests-in-chrome-for-testing` in the pipeline configuration [.circleci/test-deploy.yml](https://github.com/cypress-io/circleci-orb/blob/master/.circleci/test-deploy.yml) records into the Cypress Cloud group `2x-edge`. This is in conflict with the job `run-ct-tests-in-edge` which uses the same group and a different browser, leading to recording failures, that in turn cause the job to fail.

## Change

Record from the job `run-ct-tests-in-chrome-for-testing` in the pipeline configuration [.circleci/test-deploy.yml](https://github.com/cypress-io/circleci-orb/blob/master/.circleci/test-deploy.yml) into the Cypress Cloud group `2x-chrome-for-testing`.
