### PR TITLE
fix: correct npm branding

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -3,7 +3,7 @@ description: |
 
 parameters:
   install-command:
-    description: Overrides the default NPM command (npm ci)
+    description: Overrides the default npm command (npm ci)
     type: string
     default: ""
   post-install:
@@ -47,7 +47,7 @@ parameters:
     type: enum
     enum: ["npm", "yarn", "yarn-berry", "pnpm"]
     default: "npm"
-    description: Select the default node package manager to use. NPM v5+ Required.
+    description: Select the default node package manager to use. npm v5+ Required.
   skip-checkout:
     type: boolean
     default: false

--- a/src/examples/component.yml
+++ b/src/examples/component.yml
@@ -1,6 +1,6 @@
 description: >
   Runs Cypress component tests.
-  Installs dependencies and caches NPM modules and the Cypress binary.
+  Installs dependencies and caches npm modules and the Cypress binary.
 usage:
   version: 2.1
   orbs:

--- a/src/examples/pnpm.yml
+++ b/src/examples/pnpm.yml
@@ -1,6 +1,6 @@
 description: >
   Runs Cypress tests using pnpm.
-  Installs dependencies and caches NPM modules and the Cypress binary.
+  Installs dependencies and caches npm modules and the Cypress binary.
 usage:
   version: 2.1
   orbs:

--- a/src/examples/recording.yml
+++ b/src/examples/recording.yml
@@ -1,6 +1,6 @@
 description: >
   Runs Cypress end-to-end tests in parallel and record results to Cypress Cloud.
-  Installs dependencies and caches NPM modules and the Cypress binary.
+  Installs dependencies and caches npm modules and the Cypress binary.
 usage:
   version: 2.1
   orbs:

--- a/src/examples/run.yml
+++ b/src/examples/run.yml
@@ -1,6 +1,6 @@
 description: >
   Runs Cypress end-to-end tests without recording results to Cypress Cloud.
-  Installs dependencies and caches NPM modules and the Cypress binary.
+  Installs dependencies and caches npm modules and the Cypress binary.
 usage:
   version: 2.1
   orbs:

--- a/src/examples/yarn.yml
+++ b/src/examples/yarn.yml
@@ -1,6 +1,6 @@
 description: >
   Runs Cypress tests using yarn.
-  Installs dependencies and caches NPM modules and the Cypress binary.
+  Installs dependencies and caches npm modules and the Cypress binary.
 usage:
   version: 2.1
   orbs:

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -10,7 +10,7 @@ resource_class: << parameters.resource_class >>
 
 parameters:
   install-command:
-    description: Overrides the default NPM command (npm ci)
+    description: Overrides the default npm command (npm ci)
     type: string
     default: ""
   post-install:
@@ -54,7 +54,7 @@ parameters:
     type: enum
     enum: ["npm", "yarn", "yarn-berry", "pnpm"]
     default: "npm"
-    description: Select the default node package manager to use. NPM v5+ Required.
+    description: Select the default node package manager to use. npm v5+ Required.
   start-command:
     description: Command used to start your local dev server for Cypress to tests against
     type: string


### PR DESCRIPTION
## Situation

- The Cypress CircleCI Orb uses upper-case "NPM" in text
- [FAQ on npm branding](https://github.com/npm/cli#faq-on-branding) specifies:
  > Is it "npm" or "NPM" or "Npm"?
  > npm should never be capitalized unless it is being displayed in a location that is customarily all-capitals (ex. titles on man pages).

## Change

Correct text usage of "npm" to conform to official [npm branding](https://github.com/npm/cli#faq-on-branding)