### PR TITLE
feat!: update default Node.js to 22.17.0

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -11,7 +11,6 @@ jobs:
   install-and-persist:
     executor:
       name: cypress/default
-      node-version: "22.14.0"
     steps:
       - cypress/install:
           working-directory: examples/angular-app
@@ -24,7 +23,7 @@ jobs:
             - project
   run-ct-tests-in-chrome:
     docker:
-      - image: cypress/browsers:22.16.0
+      - image: cypress/browsers:22.17.0
     parallelism: 2
     steps:
       - run: echo "This step assumes dependencies were installed using the cypress/install job"
@@ -47,7 +46,7 @@ jobs:
           cypress-command: "npx cypress run --component --parallel --record --group 2x-chrome-for-testing --browser chrome-for-testing"
   run-ct-tests-in-firefox:
     docker:
-      - image: cypress/browsers:22.16.0
+      - image: cypress/browsers:22.17.0
     parallelism: 2
     steps:
       - run: echo "This step assumes dependencies were installed using the cypress/install job"
@@ -84,10 +83,10 @@ workflows:
           name: Custom Node Version Example
           working-directory: examples/npm-install
           cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "examples/npm-install/package.json" }}
-          node-version: "20.15.1"
+          node-version: "22.17.0"
           post-install: |
-            if ! node --version | grep -q "20.15.1"; then
-                echo "Node version 20.15.1 not found"
+            if ! node --version | grep -q "22.17.0"; then
+                echo "Node version 22.17.0 not found"
                 exit 1
             fi
       - cypress/run:
@@ -100,7 +99,6 @@ workflows:
       - cypress/run:
           filters: *filters
           name: Pnpm Example
-          node-version: "22.14.0"
           working-directory: examples/pnpm-install
           cypress-cache-key: cypress-cache{{ arch }}-{{ checksum "examples/pnpm-install/package.json" }}
           post-install: "pnpm cypress install"

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ A typical project can have:
 ```yaml
 version: 2.1
 orbs:
-  # "cypress-io/cypress@4" installs the latest published
+  # "cypress-io/cypress@5" installs the latest published
   # version "s.x.y" of the orb. We recommend you then use
-  # the strict explicit version "cypress-io/cypress@4.x.y"
+  # the strict explicit version "cypress-io/cypress@5.x.y"
   # to lock the version and prevent unexpected CI changes
-  cypress: cypress-io/cypress@4
+  cypress: cypress-io/cypress@5
 workflows:
   build:
     jobs:
@@ -66,7 +66,7 @@ may have:
 ```yaml
 version: 2.1
 orbs:
-  cypress: cypress-io/cypress@4
+  cypress: cypress-io/cypress@5
 workflows:
   build:
     jobs:
@@ -135,7 +135,7 @@ A single Docker container used to run Cypress tests. This default executor exten
 ```yaml
 version: 2.1
 orbs:
-  cypress: cypress-io/cypress@4
+  cypress: cypress-io/cypress@5
 executor: cypress/default
 jobs:
   - cypress/run:
@@ -146,10 +146,10 @@ You can also use your own executor by passing in your own Docker image. See the 
 ```yaml
 version: 2.1
 orbs:
-  cypress: cypress-io/cypress@4
+  cypress: cypress-io/cypress@5
 executor:
   docker:
-    image: cypress/browsers:22.15.0 # your Docker image here
+    image: cypress/browsers:22.17.0 # your Docker image here
 jobs:
   - cypress/run:
 ```
@@ -161,7 +161,7 @@ jobs:
 ```yaml
 version: 2.1
 orbs:
-  cypress: cypress-io/cypress@4
+  cypress: cypress-io/cypress@5
 jobs:
   install:
     executor: cypress/default
@@ -199,7 +199,7 @@ Cypress orb is _versioned_ so you can be sure that the configuration will _not_ 
 
 You can find all changes and published orb versions for Cypress orb at [cypress-io/circleci-orb/releases](https://github.com/cypress-io/circleci-orb/releases).
 
-We are using `cypress-io/cypress@4` version in our examples, so you get the latest published orb version `4.x.x`. But we recommend locking it down to an exact version to prevent unexpected changes from suddenly breaking your builds.
+We are using `cypress-io/cypress@5` version in our examples, so you get the latest published orb version `5.x.x`. But we recommend locking it down to an exact version to prevent unexpected changes from suddenly breaking your builds.
 
 ### License
 

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -9,4 +9,4 @@ display:
 
 orbs:
   node: circleci/node@7
-  browser-tools: circleci/browser-tools@2.1.1
+  browser-tools: circleci/browser-tools@2.1.2

--- a/src/examples/browser.yml
+++ b/src/examples/browser.yml
@@ -1,9 +1,12 @@
 description: >
-  Run Cypress tests using specified browser. `install_browsers: true` installs the default browsers Chrome and Firefox with the geckodriver, and the optional browsers Chrome for Testing and Edge from the CircleCI Browser Tools orb at https://circleci.com/developer/orbs/orb/circleci/browser-tools#commands-install_browser_tools.
+  Run Cypress tests using specified browser.
+  `install_browsers: true` installs the default browsers Chrome and Firefox with the geckodriver,
+  and the optional browsers Chrome for Testing and Edge from the CircleCI Browser Tools orb at
+  https://circleci.com/developer/orbs/orb/circleci/browser-tools#commands-install_browser_tools.
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@4
+    cypress: cypress-io/cypress@5
   workflows:
     use-my-orb:
       jobs:

--- a/src/examples/caching.yml
+++ b/src/examples/caching.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@4
+    cypress: cypress-io/cypress@5
   workflows:
     use-my-orb:
       jobs:

--- a/src/examples/commands.yml
+++ b/src/examples/commands.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@4
+    cypress: cypress-io/cypress@5
   jobs:
     install-and-persist:
       executor: cypress/default

--- a/src/examples/component.yml
+++ b/src/examples/component.yml
@@ -4,7 +4,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@4
+    cypress: cypress-io/cypress@5
   workflows:
     use-my-orb:
       jobs:

--- a/src/examples/custom-install.yml
+++ b/src/examples/custom-install.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@4
+    cypress: cypress-io/cypress@5
   workflows:
     use-my-orb:
       jobs:

--- a/src/examples/edge.yml
+++ b/src/examples/edge.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@4
+    cypress: cypress-io/cypress@5
   workflows:
     use-my-orb:
       jobs:

--- a/src/examples/mono-repo.yml
+++ b/src/examples/mono-repo.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@4
+    cypress: cypress-io/cypress@5
   workflows:
     use-my-orb:
       jobs:

--- a/src/examples/node-version.yml
+++ b/src/examples/node-version.yml
@@ -3,12 +3,12 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@4
+    cypress: cypress-io/cypress@5
   jobs:
     run-cypress-in-specified-node-version:
       executor:
         name: cypress/default
-        node-version: "20.6"
+        node-version: "22.17"
       steps:
         - cypress/install:
             package-manager: "npm"
@@ -19,4 +19,4 @@ usage:
     use-my-orb:
       jobs:
         - run-cypress-in-specified-node-version:
-            name: Run Cypress in Node 20
+            name: Run Cypress in Node 22.17

--- a/src/examples/pnpm.yml
+++ b/src/examples/pnpm.yml
@@ -4,7 +4,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@4
+    cypress: cypress-io/cypress@5
   workflows:
     use-my-orb:
       jobs:

--- a/src/examples/recording.yml
+++ b/src/examples/recording.yml
@@ -4,7 +4,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@4
+    cypress: cypress-io/cypress@5
   workflows:
     use-my-orb:
       jobs:

--- a/src/examples/run.yml
+++ b/src/examples/run.yml
@@ -4,7 +4,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@4
+    cypress: cypress-io/cypress@5
   workflows:
     use-my-orb:
       jobs:

--- a/src/examples/wait-on.yml
+++ b/src/examples/wait-on.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@4
+    cypress: cypress-io/cypress@5
   workflows:
     use-my-orb:
       jobs:

--- a/src/examples/yarn.yml
+++ b/src/examples/yarn.yml
@@ -4,7 +4,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@4
+    cypress: cypress-io/cypress@5
   workflows:
     use-my-orb:
       jobs:

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -3,7 +3,7 @@ description: >
 parameters:
   node-version:
     type: string
-    default: "22.15.0" # keep in sync with jobs/run.yml
+    default: "22.17.0" # keep in sync with jobs/run.yml
     description: >
       The version of Node to run your tests with.
 docker:

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -71,7 +71,7 @@ parameters:
       (requires `parallel` and `record` flags in your `cypress-command`)
   node-version:
     type: string
-    default: "22.15.0" # keep in sync with executors/default.yml
+    default: "22.17.0" # keep in sync with executors/default.yml
     description: >
       The version of Node to run your tests with.
   skip-checkout:


### PR DESCRIPTION
BREAKING CHANGE: Update to Ubuntu 24.04.2 LTS in underlying Docker image

- closes https://github.com/cypress-io/circleci-orb/issues/540

## Situation

Orb defaults to Node.js `22.15.0` and uses CircleCI Docker image `cimg/node:22.15.0-browsers`

https://github.com/cypress-io/circleci-orb/blob/6718c5b519197c68f2aa0c82126b15debc24abd2/src/executors/default.yml#L1-L10

- Prior to resolution of issue https://github.com/CircleCI-Public/cimg-node/issues/462, current CircleCI `cimg/node` images were being generated to use the outdated image Ubuntu `22.04.3` LTS release from August 2023 (see [Ubuntu releases](https://wiki.ubuntu.com/Releases) for a historical list of each of the Ubuntu releases).

## Change

- Update the default Node.js from `22.15.0` to `22.17.0`from the [Active LTS Node.js](https://github.com/nodejs/release#release-schedule) release line.

This is a breaking change because of the underlying Docker image operating system migration from Ubuntu `22.04.3` LTS to Ubuntu `24.04.2` LTS

- Update CircleCI Orb usage [circleci/browser-tools](https://circleci.com/developer/orbs/orb/circleci/browser-tools) from `2.1.1` to `2.1.2` (branding text changes in logs only)

- In [.circleci/test-deploy.yml](https://github.com/cypress-io/circleci-orb/blob/master/.circleci/test-deploy.yml) for tests using the `cypress/default` executor, use also the default `node-version` from the executor.

- For overall consistency, update general Node.js usage to 22.17.0
  - update Cypress Docker image usage to `cypress/browsers:22.17.0`
  - update custom Node.js example to `22.17.0`

- Update README documentation and examples to `cypress-io/cypress@5`
