### PR TITLE
docs: update contributing conventional commit message advice

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,13 +71,20 @@ circleci local execute orb-tools/review
 
 ### Commits
 
-Use [simple semantic commit convention](https://github.com/bahmutov/simple-commit-message), just prefix your commits. For example:
+Refer to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and use this convention for the titles of Pull Requests and of commits. These are used when automatically generating a release note change log, shown in GitHub under [Releases](https://github.com/cypress-io/circleci-orb/releases).
 
-```text
-major: breaking change
-minor: new feature added
-fix: a patch release
-```
+Commit types often used in this repo are:
+
+- `feat:` A new feature
+- `fix:` A bug fix
+- `docs:` Documentation only changes
+- `chore:` Changes that have no user-facing impact
+- `test:` Add or change example tests
+- `ci:` Changes to CI configuration
+
+For a breaking change that needs to be released with a new major version number of the Orb, mark it with the following tag in the body of the commit:
+
+ - `BREAKING CHANGE:`
 
 ### Releasing
 


### PR DESCRIPTION
## Situation

The [CONTRIBUTING > Commits](https://github.com/cypress-io/circleci-orb/blob/master/CONTRIBUTING.md#commits) document section links to an unmaintained repo https://github.com/bahmutov/simple-commit-message (last release in 2021) which is not the definitive reference for commit message syntax used in CircleCI Orbs. It contains the following text, describing a non-standard usage of commit types `major` and `minor`, which is also not typical in other Cypress repos:

---

### Commits

Use [simple semantic commit convention](https://github.com/bahmutov/simple-commit-message), just prefix your commits. For example:

```text
major: breaking change
minor: new feature added
fix: a patch release
```
---

The associated npm package [simple-commit-message](https://www.npmjs.com/package/simple-commit-message) is not otherwise used in the Cypress CircleCI Orb.

In contrast, the link to the CircleCI document [Publishing orbs](https://circleci.com/docs/creating-orbs/) links to a primary and up-to-date reference source [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) at the URL https://www.conventionalcommits.org/en/v1.0.0/



## Change

In [CONTRIBUTING > Commits](https://github.com/cypress-io/circleci-orb/blob/master/CONTRIBUTING.md#commits) remove the link to https://github.com/bahmutov/simple-commit-message and use instead https://www.conventionalcommits.org/en/v1.0.0/

Suggest commit types that have been used in recent PRs:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- chore: Changes that have no user-facing impact
- test: Add or change example tests
- ci: Changes to CI configuration

 and

 - BREAKING CHANGE: