### PR TITLE
test: migrate Chrome and Firefox tests to orb executor

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
-  orb-tools: circleci/orb-tools@12.3.1
-  browser-tools: circleci/browser-tools@2.1.2
+  orb-tools: circleci/orb-tools@12.3.1 # https://circleci.com/developer/orbs/orb/circleci/orb-tools
+  browser-tools: circleci/browser-tools@2.1.2 # https://circleci.com/developer/orbs/orb/circleci/browser-tools
   # The orb will be injected here by the "continue" job.
 filters: &filters
   tags:
@@ -22,13 +22,14 @@ jobs:
             - .cache/Cypress
             - project
   run-ct-tests-in-chrome:
-    docker:
-      - image: cypress/browsers:22.17.0
+    executor:
+      name: cypress/default
     parallelism: 2
     steps:
       - run: echo "This step assumes dependencies were installed using the cypress/install job"
       - attach_workspace:
           at: ~/
+      - browser-tools/install_chrome
       - cypress/run-tests:
           working-directory: examples/angular-app
           cypress-command: "npx cypress run --component --parallel --record --group 2x-chrome --browser chrome"
@@ -45,13 +46,14 @@ jobs:
           working-directory: examples/angular-app
           cypress-command: "npx cypress run --component --parallel --record --group 2x-chrome-for-testing --browser chrome-for-testing"
   run-ct-tests-in-firefox:
-    docker:
-      - image: cypress/browsers:22.17.0
+    executor:
+      name: cypress/default
     parallelism: 2
     steps:
       - run: echo "This step assumes dependencies were installed using the cypress/install job"
       - attach_workspace:
           at: ~/
+      - browser-tools/install_firefox
       - cypress/run-tests:
           working-directory: examples/angular-app
           cypress-command: "npx cypress run --component --parallel --record --group 2x-firefox --browser firefox"


### PR DESCRIPTION
- closes https://github.com/cypress-io/circleci-orb/issues/544

## Situation

CI tests in [.circleci/test-deploy.yml](https://github.com/cypress-io/circleci-orb/blob/master/.circleci/test-deploy.yml) include Component Testing of the [examples/angular-app](https://github.com/cypress-io/circleci-orb/tree/master/examples/angular-app) in different browsers, using two different executors:

| job                                  | executor                   | type         |
| ------------------------------------ | -------------------------- | ------------ |
| `run-ct-tests-in-chrome`             | `cypress/browsers:22.17.0` | docker image |
| `run-ct-tests-in-chrome-for-testing` | `cypress/default`          | orb executor |
| `run-ct-tests-in-firefox`            | `cypress/browsers:22.17.0` | docker image |
| `run-ct-tests-in-edge`               | `cypress/default`          | orb executor |

## Change

For the following two jobs in [.circleci/test-deploy.yml](https://github.com/cypress-io/circleci-orb/blob/master/.circleci/test-deploy.yml):

- `run-ct-tests-in-chrome`
- `run-ct-tests-in-firefox`

install the corresponding browsers using `circleci/browser-tools` and run the jobs in the `cypress/default` executor instead of in a Cypress Docker image `cypress/browsers`.

This makes the CT browser tests consistent across the board and increases the test coverage for browser provisioning through `circleci/browser-tools`.
