### PR TITLE
test: remove duplicate checkout in Verify resource_class config works

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -150,8 +150,6 @@ workflows:
           cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "examples/angular-app/package.json" }}
           cypress-command: "npx cypress run --component --parallel --record"
           resource_class: small
-          pre-steps:
-            - checkout
       - install-and-persist:
           filters: *filters
           name: Install & Persist


### PR DESCRIPTION
## Situation

- The job `Verify resource_class config works` in [.circleci/test-deploy.yml](https://github.com/cypress-io/circleci-orb/blob/master/.circleci/test-deploy.yml) executes the step "Checkout code" twice

## Change

- In the job `Verify resource_class config works` in [.circleci/test-deploy.yml](https://github.com/cypress-io/circleci-orb/blob/master/.circleci/test-deploy.yml) job, remove the parameter:

  ```yml
  pre-steps:
  - checkout
  ```

## Verification

View the log of the "Verify resource_class config works" job and confirm that "Checkout code" only appears once, not twice.