### PR TITLE
test: update Verify resource_class config works to medium+

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -149,7 +149,7 @@ workflows:
           working-directory: examples/angular-app
           cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "examples/angular-app/package.json" }}
           cypress-command: "npx cypress run --component --parallel --record"
-          resource_class: small
+          resource_class: medium+
           pre-steps:
             - checkout
       - install-and-persist:


### PR DESCRIPTION
## Situation

- The job `Verify resource_class config works` in [.circleci/test-deploy.yml](https://github.com/cypress-io/circleci-orb/blob/master/.circleci/test-deploy.yml) runs component testing of [examples/angular-app](https://github.com/cypress-io/circleci-orb/tree/master/examples/angular-app) and specifies `resource_class: small`
- Cypress documentation [System requirements](https://docs.cypress.io/app/get-started/install-cypress#System-requirements) specifies:
  - [CPU](https://docs.cypress.io/app/get-started/install-cypress#CPU) minimum 2 CPUs, plus additional CPUs for app servers
  - [Memory](https://docs.cypress.io/app/get-started/install-cypress#Memory) 4GB minimum, 8GB+ for longer test runs
- CircleCI [Docker execution environment](https://circleci.com/docs/configuration-reference/#docker-execution-environment) lists:

  | Class    | vCPUs | RAM  |
  | -------- | ----- | ---- |
  | small    | 1     | 2GB  |
  | medium   | 2     | 4GB  |
  | medium+  | 3     | 6GB  |
  | large    | 4     | 8GB  |
  | xlarge   | 8     | 16GB |
  | 2xlarge  | 16    | 32GB |
  | 2xlarge+ | 20    | 40GB |
- The selected `resource_class` of `small` therefore does not meet the Cypress minimum requirements.

## Assessment

- Assuming that component testing counts as an additional server (open issue https://github.com/cypress-io/cypress-documentation/issues/6217), the minimum requirement would be 3 CPUs and 4GB, pointing to the CircleCI `medium+` class as a minimum.

## Change

Modify the job `Verify resource_class config works` in [.circleci/test-deploy.yml](https://github.com/cypress-io/circleci-orb/blob/master/.circleci/test-deploy.yml) to use `medium+` setting for `resource_class` instead of `small`.