### PR TITLE
fix(deps): update browser-tools to 2.2.1

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   orb-tools: circleci/orb-tools@12.3.1 # https://circleci.com/developer/orbs/orb/circleci/orb-tools
-  browser-tools: circleci/browser-tools@2.1.2 # https://circleci.com/developer/orbs/orb/circleci/browser-tools
+  browser-tools: circleci/browser-tools@2.2.1 # https://circleci.com/developer/orbs/orb/circleci/browser-tools
   # The orb will be injected here by the "continue" job.
 filters: &filters
   tags:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -9,4 +9,4 @@ display:
 
 orbs:
   node: circleci/node@7
-  browser-tools: circleci/browser-tools@2.1.2
+  browser-tools: circleci/browser-tools@2.2.1

--- a/src/examples/browser.yml
+++ b/src/examples/browser.yml
@@ -1,6 +1,6 @@
 description: >
   Run Cypress tests using specified browser.
-  `install_browsers: true` installs the default browsers Chrome and Firefox with the geckodriver,
+  `install-browsers: true` installs the default browsers Chrome and Firefox with the geckodriver,
   and the optional browsers Chrome for Testing and Edge from the CircleCI Browser Tools orb at
   https://circleci.com/developer/orbs/orb/circleci/browser-tools#commands-install_browser_tools.
 usage:


### PR DESCRIPTION
- closes https://github.com/cypress-io/circleci-orb/issues/551

## Situation

The Google Chrome for Testing 139 distribution package contains a permissions restriction which caused browser installation to fail. This affected pipelines using `cypress-io/cypress@4.2.0` and the `install-browsers` option with the `run` job or `install` command.

## Change

Update the [circleci/browser-tools](https://circleci.com/developer/orbs/orb/circleci/browser-tools) version from

[circleci/browser-tools@2.1.2](https://github.com/CircleCI-Public/browser-tools-orb/releases/tag/v2.1.2)

to

[circleci/browser-tools@2.2.1](https://github.com/CircleCI-Public/browser-tools-orb/releases/tag/v2.2.1)

---

Also fix a typo in [src/examples/browser.yml](https://github.com/cypress-io/circleci-orb/blob/master/src/examples/browser.yml), changing `install_browsers` (snake case) to `install-browsers` (kebab case).

Although [circleci/browser-tools@2.0.0](https://github.com/CircleCI-Public/browser-tools-orb/releases/tag/v2.0.0) included the breaking change of making all commands snake case (using underscores) replacing kebab case (using hyphens), the Cypress Orb has retained the use of kebab case for its own options. So there are two different schemes in use in parallel.
