### PR TITLE
feat!: update default Node.js to 24.11.0 (Active LTS)

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -85,10 +85,10 @@ workflows:
           name: Custom Node Version Example
           working-directory: examples/npm-install
           cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "examples/npm-install/package.json" }}
-          node-version: "22.17.0"
+          node-version: "24.11.0"
           post-install: |
-            if ! node --version | grep -q "22.17.0"; then
-                echo "Node version 22.17.0 not found"
+            if ! node --version | grep -q "24.11.0"; then
+                echo "Node version 24.11.0 not found"
                 exit 1
             fi
       - cypress/run:

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ A typical project can have:
 ```yaml
 version: 2.1
 orbs:
-  # "cypress-io/cypress@5" installs the latest published
+  # "cypress-io/cypress@6" installs the latest published
   # version "s.x.y" of the orb. We recommend you then use
-  # the strict explicit version "cypress-io/cypress@5.x.y"
+  # the strict explicit version "cypress-io/cypress@6.x.y"
   # to lock the version and prevent unexpected CI changes
-  cypress: cypress-io/cypress@5
+  cypress: cypress-io/cypress@6
 workflows:
   build:
     jobs:
@@ -66,7 +66,7 @@ may have:
 ```yaml
 version: 2.1
 orbs:
-  cypress: cypress-io/cypress@5
+  cypress: cypress-io/cypress@6
 workflows:
   build:
     jobs:
@@ -135,7 +135,7 @@ A single Docker container used to run Cypress tests. This default executor exten
 ```yaml
 version: 2.1
 orbs:
-  cypress: cypress-io/cypress@5
+  cypress: cypress-io/cypress@6
 executor: cypress/default
 jobs:
   - cypress/run:
@@ -146,10 +146,10 @@ You can also use your own executor by passing in your own Docker image. See the 
 ```yaml
 version: 2.1
 orbs:
-  cypress: cypress-io/cypress@5
+  cypress: cypress-io/cypress@6
 executor:
   docker:
-    image: cypress/browsers:22.17.0 # your Docker image here
+    image: cypress/browsers:24.11.0 # your Docker image here
 jobs:
   - cypress/run:
 ```
@@ -161,7 +161,7 @@ jobs:
 ```yaml
 version: 2.1
 orbs:
-  cypress: cypress-io/cypress@5
+  cypress: cypress-io/cypress@6
 jobs:
   install:
     executor: cypress/default
@@ -199,7 +199,7 @@ Cypress orb is _versioned_ so you can be sure that the configuration will _not_ 
 
 You can find all changes and published orb versions for Cypress orb at [cypress-io/circleci-orb/releases](https://github.com/cypress-io/circleci-orb/releases).
 
-We are using `cypress-io/cypress@5` version in our examples, so you get the latest published orb version `5.x.x`. But we recommend locking it down to an exact version to prevent unexpected changes from suddenly breaking your builds.
+We are using `cypress-io/cypress@6` version in our examples, so you get the latest published orb version `6.x.x`. But we recommend locking it down to an exact version to prevent unexpected changes from suddenly breaking your builds.
 
 ### License
 

--- a/src/examples/browser.yml
+++ b/src/examples/browser.yml
@@ -6,7 +6,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@5
+    cypress: cypress-io/cypress@6
   workflows:
     use-my-orb:
       jobs:

--- a/src/examples/caching.yml
+++ b/src/examples/caching.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@5
+    cypress: cypress-io/cypress@6
   workflows:
     use-my-orb:
       jobs:

--- a/src/examples/commands.yml
+++ b/src/examples/commands.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@5
+    cypress: cypress-io/cypress@6
   jobs:
     install-and-persist:
       executor: cypress/default

--- a/src/examples/component.yml
+++ b/src/examples/component.yml
@@ -4,7 +4,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@5
+    cypress: cypress-io/cypress@6
   workflows:
     use-my-orb:
       jobs:

--- a/src/examples/custom-install.yml
+++ b/src/examples/custom-install.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@5
+    cypress: cypress-io/cypress@6
   workflows:
     use-my-orb:
       jobs:

--- a/src/examples/edge.yml
+++ b/src/examples/edge.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@5
+    cypress: cypress-io/cypress@6
   workflows:
     use-my-orb:
       jobs:

--- a/src/examples/mono-repo.yml
+++ b/src/examples/mono-repo.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@5
+    cypress: cypress-io/cypress@6
   workflows:
     use-my-orb:
       jobs:

--- a/src/examples/node-version.yml
+++ b/src/examples/node-version.yml
@@ -3,12 +3,12 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@5
+    cypress: cypress-io/cypress@6
   jobs:
     run-cypress-in-specified-node-version:
       executor:
         name: cypress/default
-        node-version: "22.17"
+        node-version: "24.11"
       steps:
         - cypress/install:
             package-manager: "npm"
@@ -19,4 +19,4 @@ usage:
     use-my-orb:
       jobs:
         - run-cypress-in-specified-node-version:
-            name: Run Cypress in Node 22.17
+            name: Run Cypress in Node 24.11

--- a/src/examples/pnpm.yml
+++ b/src/examples/pnpm.yml
@@ -4,7 +4,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@5
+    cypress: cypress-io/cypress@6
   workflows:
     use-my-orb:
       jobs:

--- a/src/examples/recording.yml
+++ b/src/examples/recording.yml
@@ -4,7 +4,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@5
+    cypress: cypress-io/cypress@6
   workflows:
     use-my-orb:
       jobs:

--- a/src/examples/run.yml
+++ b/src/examples/run.yml
@@ -4,7 +4,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@5
+    cypress: cypress-io/cypress@6
   workflows:
     use-my-orb:
       jobs:

--- a/src/examples/wait-on.yml
+++ b/src/examples/wait-on.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@5
+    cypress: cypress-io/cypress@6
   workflows:
     use-my-orb:
       jobs:

--- a/src/examples/yarn.yml
+++ b/src/examples/yarn.yml
@@ -4,7 +4,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cypress: cypress-io/cypress@5
+    cypress: cypress-io/cypress@6
   workflows:
     use-my-orb:
       jobs:

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -3,7 +3,7 @@ description: >
 parameters:
   node-version:
     type: string
-    default: "22.17.0" # keep in sync with jobs/run.yml
+    default: "24.11.0" # keep in sync with jobs/run.yml
     description: >
       The version of Node to run your tests with.
 docker:

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -71,7 +71,7 @@ parameters:
       (requires `parallel` and `record` flags in your `cypress-command`)
   node-version:
     type: string
-    default: "22.17.0" # keep in sync with executors/default.yml
+    default: "24.11.0" # keep in sync with executors/default.yml
     description: >
       The version of Node to run your tests with.
   skip-checkout:


### PR DESCRIPTION
## Situation

The Cypress Orb defaults to using Node.js `22.17.0` and the CircleCI convenience Docker image `cimg/node:22.17.0-browsers`

https://github.com/cypress-io/circleci-orb/blob/d9c2e3bbe6d8dbcd8cf15a4e2319d45f8544bbdb/src/executors/default.yml#L1-L10

The [Node.js 24.11.0 release](https://nodejs.org/en/blog/release/v24.11.0) on Oct 28, 2025, marked the transition of Node.js 24.x into Long Term Support (LTS). Node.js 22.x moved into Maintenance LTS status on Oct 21, 2025.

## Change

- Update the default Node.js from `22.17.0` to `24.11.0`from the [Active LTS Node.js](https://github.com/nodejs/release#release-schedule) release line.

This is a breaking change because of the change of major version for Node.js from 22 to 24.

- In [.circleci/test-deploy.yml](https://github.com/cypress-io/circleci-orb/blob/master/.circleci/test-deploy.yml) for tests using the `cypress/default` executor, use also the default `node-version` from the executor.

- For overall consistency, update general Node.js usage to `24.11.0`
  - update Cypress Docker image documentation usage to `cypress/browsers:24.11.0`
  - update custom Node.js example to `24.11.0`

- Update README documentation and examples to `cypress-io/cypress@6`
