### PR TITLE
feat(deps): update default Node.js to 24.13.0

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  orb-tools: circleci/orb-tools@12.3.1 # https://circleci.com/developer/orbs/orb/circleci/orb-tools
+  orb-tools: circleci/orb-tools@12.4.0 # https://circleci.com/developer/orbs/orb/circleci/orb-tools
   browser-tools: circleci/browser-tools@2.3.2 # https://circleci.com/developer/orbs/orb/circleci/browser-tools
   # The orb will be injected here by the "continue" job.
 filters: &filters
@@ -85,10 +85,10 @@ workflows:
           name: Custom Node Version Example
           working-directory: examples/npm-install
           cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "examples/npm-install/package.json" }}
-          node-version: "24.11.0"
+          node-version: "24.13.0"
           post-install: |
-            if ! node --version | grep -q "24.11.0"; then
-                echo "Node version 24.11.0 not found"
+            if ! node --version | grep -q "24.13.0"; then
+                echo "Node.js version 24.13.0 not found"
                 exit 1
             fi
       - cypress/run:

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ orbs:
   cypress: cypress-io/cypress@6
 executor:
   docker:
-    image: cypress/browsers:24.11.0 # your Docker image here
+    image: cypress/browsers:24.13.0 # your Docker image here
 jobs:
   - cypress/run:
 ```

--- a/src/examples/node-version.yml
+++ b/src/examples/node-version.yml
@@ -1,5 +1,5 @@
 description: >
-  Runs Cypress tests using the cypress/default executor with a specified node version.
+  Runs Cypress tests using the cypress/default executor with a specified Node.js version.
 usage:
   version: 2.1
   orbs:
@@ -8,7 +8,7 @@ usage:
     run-cypress-in-specified-node-version:
       executor:
         name: cypress/default
-        node-version: "24.11"
+        node-version: "24.13"
       steps:
         - cypress/install:
             package-manager: "npm"
@@ -19,4 +19,4 @@ usage:
     use-my-orb:
       jobs:
         - run-cypress-in-specified-node-version:
-            name: Run Cypress in Node 24.11
+            name: Run Cypress in Node.js 24.13

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -3,8 +3,8 @@ description: >
 parameters:
   node-version:
     type: string
-    default: "24.11.0" # keep in sync with jobs/run.yml
+    default: "24.13.0" # keep in sync with jobs/run.yml
     description: >
-      The version of Node to run your tests with.
+      The version of Node.js to run your tests with.
 docker:
   - image: cimg/node:<< parameters.node-version >>-browsers

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -71,9 +71,9 @@ parameters:
       (requires `parallel` and `record` flags in your `cypress-command`)
   node-version:
     type: string
-    default: "24.11.0" # keep in sync with executors/default.yml
+    default: "24.13.0" # keep in sync with executors/default.yml
     description: >
-      The version of Node to run your tests with.
+      The version of Node.js to run your tests with.
   skip-checkout:
     type: boolean
     default: false


### PR DESCRIPTION
## Situation

The Cypress Orb currently defaults to using Node.js `24.11.0` and the CircleCI convenience Docker image `cimg/node:22.11.0-browsers`

https://github.com/cypress-io/circleci-orb/blob/032d5cfacfec472f9114f95b23819a0b8f43ba5d/src/executors/default.yml#L1-L10

The [Node.js 24.13.0 security release](https://nodejs.org/en/blog/release/v24.13.0) on Jan 13, 2026 has been built into the CircleCI convenience Docker image `cimg/node:22.13.0-browsers` that includes a fix for https://github.com/cypress-io/circleci-orb/issues/538 (Sporadic "Missing X server or $DISPLAY"). When running with this CircleCI Docker image selected, CircleCI starts Xvfb. Previous versions started Xvfb less reliably, causing Cypress to sometimes fail.

## Change

- Update the default Node.js from `24.11.0` to `24.13.0`. Both the previous and new Node.js versions belong to the the [Active LTS Node.js](https://github.com/nodejs/release#release-schedule) release line.

- In [.circleci/test-deploy.yml](https://github.com/cypress-io/circleci-orb/blob/master/.circleci/test-deploy.yml) for tests using the `cypress/default` executor, use also the default `node-version` from the executor.

- For overall consistency, update general Node.js usage to `24.13.0`
  - update Cypress Docker image documentation usage to `cypress/browsers:24.13.0`
  - update custom Node.js example to `24.13.0`

- In text, prefer "Node.js" instead of "Node" according to [Node.js style guide](https://github.com/nodejs/node/blob/main/doc/README.md)
