### PR TITLE
feat(deps): update default Node.js to 24.13.1

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -85,10 +85,10 @@ workflows:
           name: Custom Node Version Example
           working-directory: examples/npm-install
           cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "examples/npm-install/package.json" }}
-          node-version: "24.13.0"
+          node-version: "24.13.1"
           post-install: |
-            if ! node --version | grep -q "24.13.0"; then
-                echo "Node.js version 24.13.0 not found"
+            if ! node --version | grep -q "24.13.1"; then
+                echo "Node.js version 24.13.1 not found"
                 exit 1
             fi
       - cypress/run:

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ orbs:
   cypress: cypress-io/cypress@6
 executor:
   docker:
-    image: cypress/browsers:24.13.0 # your Docker image here
+    image: cypress/browsers:24.13.1 # your Docker image here
 jobs:
   - cypress/run:
 ```

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -3,7 +3,7 @@ description: >
 parameters:
   node-version:
     type: string
-    default: "24.13.0" # keep in sync with jobs/run.yml
+    default: "24.13.1" # keep in sync with jobs/run.yml
     description: >
       The version of Node.js to run your tests with.
 docker:

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -71,7 +71,7 @@ parameters:
       (requires `parallel` and `record` flags in your `cypress-command`)
   node-version:
     type: string
-    default: "24.13.0" # keep in sync with executors/default.yml
+    default: "24.13.1" # keep in sync with executors/default.yml
     description: >
       The version of Node.js to run your tests with.
   skip-checkout:


### PR DESCRIPTION
- closes https://github.com/cypress-io/circleci-orb/issues/565

## Situation

The released version of the Cypress Orb `cypress-io/cypress@6.0.0` defaults to using Node.js `24.11.0` together with the CircleCI convenience Docker image `cimg/node:24.11.0-browsers`:

https://github.com/cypress-io/circleci-orb/blob/032d5cfacfec472f9114f95b23819a0b8f43ba5d/src/executors/default.yml#L1-L10.

The `master` branch was updated through PR https://github.com/cypress-io/circleci-orb/pull/563 to Node.js 24.13.0, however this was not released:

https://github.com/cypress-io/circleci-orb/blob/fc02e8aaec7840c7f3a31c506991e34671e126bb/src/executors/default.yml#L6

The CircleCI convenience Docker image `cimg/node:22.13.1-browsers`, generated from https://github.com/CircleCI-Public/cimg-node, includes a timeout of 30 seconds waiting for the Xvfb X11 server to start. This promises to resolve issue https://github.com/cypress-io/circleci-orb/issues/565 or at least to cause it to occur less often.

## Change

- Update the default Node.js from `24.13.0` to `24.13.1`. Both the previous and new Node.js versions belong to the the [Active LTS Node.js](https://github.com/nodejs/release#release-schedule) release line.

- In [.circleci/test-deploy.yml](https://github.com/cypress-io/circleci-orb/blob/master/.circleci/test-deploy.yml) for tests using the `cypress/default` executor, use also the default `node-version` from the executor.

- For overall consistency, update general Node.js usage to `24.13.1`
  - update Cypress Docker image documentation usage to `cypress/browsers:24.13.1`
  - update custom Node.js example to `24.13.1`