### PR TITLE
feat(deps): update default Node.js to 24.15.0

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -86,10 +86,10 @@ workflows:
           name: Custom Node Version Example
           working-directory: examples/npm-install
           cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "examples/npm-install/package.json" }}
-          node-version: "24.14.1"
+          node-version: "24.15.0"
           post-install: |
-            if ! node --version | grep -q "24.14.1"; then
-                echo "Node.js version 24.14.1 not found"
+            if ! node --version | grep -q "24.15.0"; then
+                echo "Node.js version 24.15.0 not found"
                 exit 1
             fi
       - cypress/run:

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ orbs:
   cypress: cypress-io/cypress@6
 executor:
   docker:
-    image: cypress/browsers:24.14.1 # your Docker image here
+    image: cypress/browsers:24.15.0 # your Docker image here
 jobs:
   - cypress/run:
 ```

--- a/src/examples/node-version.yml
+++ b/src/examples/node-version.yml
@@ -8,7 +8,7 @@ usage:
     run-cypress-in-specified-node-version:
       executor:
         name: cypress/default
-        node-version: "24.13"
+        node-version: "24.15"
       steps:
         - cypress/install:
             package-manager: "npm"
@@ -19,4 +19,4 @@ usage:
     use-my-orb:
       jobs:
         - run-cypress-in-specified-node-version:
-            name: Run Cypress in Node.js 24.13
+            name: Run Cypress in Node.js 24.15

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -3,7 +3,7 @@ description: >
 parameters:
   node-version:
     type: string
-    default: "24.14.1" # keep in sync with jobs/run.yml
+    default: "24.15.0" # keep in sync with jobs/run.yml
     description: >
       The version of Node.js to run your tests with.
 docker:

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -71,7 +71,7 @@ parameters:
       (requires `parallel` and `record` flags in your `cypress-command`)
   node-version:
     type: string
-    default: "24.14.1" # keep in sync with executors/default.yml
+    default: "24.15.0" # keep in sync with executors/default.yml
     description: >
       The version of Node.js to run your tests with.
   skip-checkout:


### PR DESCRIPTION
## Situation

The released version of the [Cypress Orb](https://circleci.com/developer/orbs/orb/cypress-io/cypress) `cypress-io/cypress@6.0.0` defaults to using Node.js `24.11.0` together with the CircleCI convenience Docker image `cimg/node:24.11.0-browsers`.

The [cimg-node](https://github.com/CircleCI-Public/cimg-node) repo has now provided the Docker image `cimg/node:24.15.0-browsers` to the Docker Hub repo [cimg/node](https://hub.docker.com/r/cimg/node).

## Change

- Update the default Node.js version from `24.14.1` to `24.15.0`. Both the previous and new Node.js versions belong to the [Active LTS Node.js](https://github.com/nodejs/release#release-schedule) release line.

- In [.circleci/test-deploy.yml](https://github.com/cypress-io/circleci-orb/blob/master/.circleci/test-deploy.yml) for tests using the `cypress/default` executor, use also the default `node-version` from the executor.

- For overall consistency, update general Node.js usage to `24.15.0`
  - update Cypress Docker image documentation usage to `cypress/browsers:24.15.0`
  - update custom Node.js example to `24.15.0`

## Release

This PR should be released after merging. See also https://github.com/cypress-io/circleci-orb/issues/573.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default Node.js runtime used by the orb, which can affect downstream builds if there are version-specific behaviors, but it’s a small, scoped LTS patch-level bump and mostly doc/CI updates.
> 
> **Overview**
> Updates the orb’s default `node-version` from `24.14.1` to `24.15.0` in both `src/executors/default.yml` and `src/jobs/run.yml` (kept in sync).
> 
> Refreshes CI and documentation/examples to use the new version: `.circleci/test-deploy.yml` custom-node test now pins and verifies `24.15.0`, `README.md` updates the `cypress/browsers` image tag, and `src/examples/node-version.yml` updates the sample workflow name/version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 584d42e1209d4668aac876b12740558ccbcd9aea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->