### PR TITLE
feat: add max-auto-reruns parameter to run-tests command and run job

### DIFF
--- a/src/commands/run-tests.yml
+++ b/src/commands/run-tests.yml
@@ -39,11 +39,15 @@ steps:
             command: << parameters.start-command >>
             background: true
             working_directory: << parameters.working-directory >>
-  # Two variants of the Run Cypress step. Only one runs per job. The
-  # `max_auto_reruns` field is omitted entirely when max-auto-reruns is 0
-  # (the default) because the orb validator rejects `max_auto_reruns: 0`
-  # with "0 is not greater or equal to 1" — the field's value-schema
-  # requires >= 1, so the field can't be present unless retry is wanted.
+  # Two variants of the Run Cypress step. Only one runs per job.
+  # The `max_auto_reruns` field is omitted entirely when max-auto-reruns
+  # is 0 (the default) because the orb validator rejects
+  # `max_auto_reruns: 0` with "0 is not greater or equal to 1" — the
+  # field's value-schema requires >= 1, so the field can't be present
+  # unless retry is wanted. (The Mustache section-conditional syntax
+  # `<<#parameters.X>>...<</parameters.X>>` doesn't work here because
+  # the orb packer's parser can't handle a parameter substitution inside
+  # a section block of the same parameter.)
   - unless:
       condition: << parameters.max-auto-reruns >>
       steps:

--- a/src/commands/run-tests.yml
+++ b/src/commands/run-tests.yml
@@ -14,6 +14,21 @@ parameters:
     description: Command used to run your Cypress tests
     type: string
     default: "npx cypress run"
+  max-auto-reruns:
+    description: >
+      Number of additional times CircleCI should automatically rerun the
+      Cypress run step if it fails. 0 (default) disables auto-rerun. Useful
+      for known-flaky test suites where you want CircleCI's native
+      step-level retry rather than rerunning the whole workflow. See
+      https://circleci.com/docs/guides/orchestrate/automatic-reruns/
+    type: integer
+    default: 0
+  auto-rerun-delay:
+    description: >
+      Delay (e.g. "10s", "1m") between auto-rerun attempts of the Cypress
+      run step. Only applies when max-auto-reruns > 0.
+    type: string
+    default: "0s"
 
 steps:
   - when:
@@ -28,6 +43,8 @@ steps:
       name: Run Cypress
       command: << parameters.cypress-command >>
       working_directory: << parameters.working-directory >>
+      max_auto_reruns: << parameters.max-auto-reruns >>
+      auto_rerun_delay: << parameters.auto-rerun-delay >>
   - store_artifacts:
       path: << parameters.working-directory >>/cypress/videos
   - store_artifacts:

--- a/src/commands/run-tests.yml
+++ b/src/commands/run-tests.yml
@@ -21,14 +21,14 @@ parameters:
       for known-flaky test suites where you want CircleCI's native
       step-level retry rather than rerunning the whole workflow. See
       https://circleci.com/docs/guides/orchestrate/automatic-reruns/
+
+      auto_rerun_delay is intentionally not exposed as a parameter — the
+      CircleCI orb validator pre-checks the delay value against a
+      time-format regex before substituting parameters, which fails on
+      any "<< parameters.x >>" expression. Reruns happen with the default
+      0s delay; if you need a delay, file an issue.
     type: integer
     default: 0
-  auto-rerun-delay:
-    description: >
-      Delay (e.g. "10s", "1m") between auto-rerun attempts of the Cypress
-      run step. Only applies when max-auto-reruns > 0.
-    type: string
-    default: "0s"
 
 steps:
   - when:
@@ -44,7 +44,6 @@ steps:
       command: << parameters.cypress-command >>
       working_directory: << parameters.working-directory >>
       max_auto_reruns: << parameters.max-auto-reruns >>
-      auto_rerun_delay: << parameters.auto-rerun-delay >>
   - store_artifacts:
       path: << parameters.working-directory >>/cypress/videos
   - store_artifacts:

--- a/src/commands/run-tests.yml
+++ b/src/commands/run-tests.yml
@@ -39,11 +39,26 @@ steps:
             command: << parameters.start-command >>
             background: true
             working_directory: << parameters.working-directory >>
-  - run:
-      name: Run Cypress
-      command: << parameters.cypress-command >>
-      working_directory: << parameters.working-directory >>
-      max_auto_reruns: << parameters.max-auto-reruns >>
+  # Two variants of the Run Cypress step. Only one runs per job. The
+  # `max_auto_reruns` field is omitted entirely when max-auto-reruns is 0
+  # (the default) because the orb validator rejects `max_auto_reruns: 0`
+  # with "0 is not greater or equal to 1" — the field's value-schema
+  # requires >= 1, so the field can't be present unless retry is wanted.
+  - unless:
+      condition: << parameters.max-auto-reruns >>
+      steps:
+        - run:
+            name: Run Cypress
+            command: << parameters.cypress-command >>
+            working_directory: << parameters.working-directory >>
+  - when:
+      condition: << parameters.max-auto-reruns >>
+      steps:
+        - run:
+            name: Run Cypress
+            command: << parameters.cypress-command >>
+            working_directory: << parameters.working-directory >>
+            max_auto_reruns: << parameters.max-auto-reruns >>
   - store_artifacts:
       path: << parameters.working-directory >>/cypress/videos
   - store_artifacts:

--- a/src/examples/auto-rerun.yml
+++ b/src/examples/auto-rerun.yml
@@ -1,0 +1,20 @@
+description: >
+  Auto-retry the Cypress run step up to 2 additional times on failure
+  using CircleCI's native step-level max_auto_reruns. Useful for known-flaky
+  test suites where you want the retry scoped to the Cypress invocation
+  itself rather than rerunning the whole workflow.
+
+  When max-auto-reruns is omitted (default 0), no auto-rerun is configured
+  and the step behaves exactly as before.
+
+usage:
+  version: 2.1
+  orbs:
+    cypress: cypress-io/cypress@6
+  workflows:
+    use-my-orb:
+      jobs:
+        - cypress/run:
+            start-command: "npm run start"
+            max-auto-reruns: 2
+            auto-rerun-delay: "10s"

--- a/src/examples/auto-rerun.yml
+++ b/src/examples/auto-rerun.yml
@@ -17,4 +17,3 @@ usage:
         - cypress/run:
             start-command: "npm run start"
             max-auto-reruns: 2
-            auto-rerun-delay: "10s"

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -72,12 +72,6 @@ parameters:
       See https://circleci.com/docs/guides/orchestrate/automatic-reruns/
     type: integer
     default: 0
-  auto-rerun-delay:
-    description: >
-      Delay (e.g. "10s", "1m") between auto-rerun attempts of the
-      Cypress run step. Only applies when max-auto-reruns > 0.
-    type: string
-    default: "0s"
   parallelism:
     type: integer
     default: 1
@@ -126,4 +120,3 @@ steps:
       start-command: << parameters.start-command >>
       cypress-command: << parameters.cypress-command >>
       max-auto-reruns: << parameters.max-auto-reruns >>
-      auto-rerun-delay: << parameters.auto-rerun-delay >>

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -63,6 +63,21 @@ parameters:
     description: Command used to run your Cypress tests
     type: string
     default: "npx cypress run"
+  max-auto-reruns:
+    description: >
+      Number of additional times CircleCI should automatically rerun the
+      Cypress run step if it fails. 0 (default) disables auto-rerun.
+      Useful for known-flaky test suites where you want CircleCI's
+      native step-level retry rather than rerunning the whole workflow.
+      See https://circleci.com/docs/guides/orchestrate/automatic-reruns/
+    type: integer
+    default: 0
+  auto-rerun-delay:
+    description: >
+      Delay (e.g. "10s", "1m") between auto-rerun attempts of the
+      Cypress run step. Only applies when max-auto-reruns > 0.
+    type: string
+    default: "0s"
   parallelism:
     type: integer
     default: 1
@@ -110,3 +125,5 @@ steps:
       working-directory: << parameters.working-directory >>
       start-command: << parameters.start-command >>
       cypress-command: << parameters.cypress-command >>
+      max-auto-reruns: << parameters.max-auto-reruns >>
+      auto-rerun-delay: << parameters.auto-rerun-delay >>


### PR DESCRIPTION
## Summary

Adds a `max-auto-reruns` parameter to both the `cypress/run-tests` command and `cypress/run` job. The parameter is threaded through to CircleCI's [step-level `max_auto_reruns`](https://circleci.com/docs/guides/orchestrate/automatic-reruns/) on the internal "Run Cypress" run step.

```yaml
- cypress/run:
    max-auto-reruns: 2
```

## Motivation

Today the only way for an orb consumer to get auto-retry on flaky Cypress runs is to apply `max_auto_reruns` at the **workflow** level, which retries every failed job in the workflow — including non-flaky ones like lint/typecheck/spellcheck — and burns CI minutes on real failures that would never recover.

Step-level `max_auto_reruns` lets you scope the retry budget to just the Cypress invocation, where it's actually needed (Vite startup races, browser crashes, transient network blips, etc.). Combined with Cypress's per-test `retries: { runMode: N }`, you get layered flake protection without affecting other jobs.

## Behavior

`max-auto-reruns` defaults to `0` (disabled), so callers who don't set it see no behavior change.

## What was dropped from the original draft

The first commit also added an `auto-rerun-delay` parameter, but `orb-tools/pack` rejected it: the CircleCI orb validator pre-checks the time-format regex (`^((10|[1-9])m|([1-9][0-9]*)s)$`) against the literal `<< parameters.auto-rerun-delay >>` string before substituting the parameter, which always fails. Integer parameters like `max_auto_reruns` aren't affected because they're typed `integer` and skip the pattern step.

I dropped `auto-rerun-delay` so this PR doesn't depend on a CLI fix. Reruns happen with the runtime's default `0s` delay; if a delay becomes important later, the orb can hardcode one or wait for the upstream CLI fix tracked at **CircleCI-Public/circleci-cli#1202**.

## Test plan

- [x] `circleci orb pack ./src && circleci orb validate orb.yml` passes locally
- [x] `orb-tools/pack` and `orb-tools/lint` pass in CI
- [ ] Once published as a `dev:` build, validate end-to-end against a real Cypress job by triggering a flaky run and confirming the step retries (will be done from a downstream consumer pipeline)