### PR TITLE
chore(renovate): include src/@orb.yml in Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,20 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "circleci": {
+    "managerFilePatterns": ["src/@orb.yml"]
+  },
+  "packageRules": [
+    {
+      "matchManagers": ["circleci"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "semanticCommitType": "fix"
+    },
+    {
+      "matchManagers": ["circleci"],
+      "matchUpdateTypes": ["major"],
+      "semanticCommitType": "feat"
+    }
   ]
 }


### PR DESCRIPTION
## Situation

Although there has been a [renovate.json](https://github.com/cypress-io/circleci-orb/blob/master/renovate.json) configuration in this repo for many years, it appears that it was never suitably configured.

Two issues are seen in the auto-generated Renovate PR https://github.com/cypress-io/circleci-orb/pull/578:

1. Renovate does not update [src/@orb.yml](https://github.com/cypress-io/circleci-orb/blob/master/src/%40orb.yml), leaving the orb in an inconsistent state if only<br>`browser-tools: circleci/browser-tools` in [.circleci/test-deploy.yml](https://github.com/cypress-io/circleci-orb/blob/master/.circleci/test-deploy.yml) is updated.
2. The commit message is `chore(deps)` although the change affects the end-use of the orb, and should be shown as `fix(deps)` for correct changelog generation.

## Assessment

The [renovate.json](https://github.com/cypress-io/circleci-orb/blob/master/renovate.json) uses only the [config:recommended](https://docs.renovatebot.com/presets-config/#configrecommended) preset with no other settings. This includes [:semanticPrefixFixDepsChoreOthers](https://docs.renovatebot.com/presets-default/#semanticprefixfixdepschoreothers), which is not set up for CircleCI orbs.

The [Renovate CircleCI](https://docs.renovatebot.com/modules/manager/circleci/) default File Matching specifies `/(^|/)\.circleci/.+\.ya?ml$/` and this does not include matching [src/@orb.yml](https://github.com/cypress-io/circleci-orb/blob/master/src/%40orb.yml).

## Change

For `circleci`:

1. Include `src/@orb.yml` in `managerFilePatterns`
2. Add `packageRules` to set `semanticCommitType` to `fix` or `feat`

## Notes

- This will cause `node: circleci/node@7` to be pinned to a set version (currently `7.2.1`) of [circleci/node](https://circleci.com/developer/orbs/orb/circleci/node) in [src/@orb.yml](https://github.com/cypress-io/circleci-orb/blob/master/src/%40orb.yml). This is in any case better practice and aligns both orb selections in this source file to use pinned versions.

## Reference

https://docs.renovatebot.com/config-overview/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only Renovate configuration (dependency update automation) and does not affect runtime code; main impact is different files/commit types for future Renovate PRs.
> 
> **Overview**
> Updates `renovate.json` to have Renovate’s `circleci` manager also scan `src/@orb.yml`, preventing orb dependency drift between source and CI configs.
> 
> Adds `packageRules` so CircleCI dependency updates use semantic commit types: `fix` for minor/patch/pin/digest updates and `feat` for major updates, improving changelog/release semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4df1860a2f9c6001c31cd95ebdb5efaf4b03628f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->