### PR TITLE
chore(renovate): add renovate label to config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "labels": ["renovate"],
   "circleci": {
     "managerFilePatterns": ["src/@orb.yml"]
   },


### PR DESCRIPTION
## Situation

A new label https://github.com/cypress-io/circleci-orb/labels/renovate has been added to the repo.

This label is not yet used in the [renovate.json](https://github.com/cypress-io/circleci-orb/blob/master/renovate.json) configuration.

## Change

Add the https://github.com/cypress-io/circleci-orb/labels/renovate label to the [renovate.json](https://github.com/cypress-io/circleci-orb/blob/master/renovate.json) configuration so that future PRs created by Renovate will be automatically labeled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: configuration-only change that affects only how Renovate-created PRs are labeled, with no impact on runtime behavior.
> 
> **Overview**
> Adds a `labels: ["renovate"]` setting to `renovate.json` so that future Renovate dependency-update PRs are automatically tagged with the `renovate` label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2f42c8dada6c246942205a4d957b7d4a07beea2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->