### PR TITLE
chore: add minimum release age and vulnerability alerts to renovate config

### DIFF
--- a/examples/pnpm-install/package.json
+++ b/examples/pnpm-install/package.json
@@ -9,10 +9,5 @@
   "private": true,
   "devDependencies": {
     "cypress": "^15.0.0"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "cypress"
-    ]
   }
 }

--- a/examples/pnpm-install/pnpm-workspace.yaml
+++ b/examples/pnpm-install/pnpm-workspace.yaml
@@ -1,1 +1,3 @@
 sideEffectsCache: false
+onlyBuiltDependencies:
+  - cypress

--- a/examples/pnpm-install/pnpm-workspace.yaml
+++ b/examples/pnpm-install/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
 sideEffectsCache: false
-onlyBuiltDependencies:
-  - cypress
+allowBuilds:
+  cypress: true

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,11 @@
   "extends": [
     "config:recommended"
   ],
+  "minimumReleaseAge": "7 days",
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "minimumReleaseAge": "0 days"
+  },
   "labels": ["renovate"],
   "circleci": {
     "managerFilePatterns": ["src/@orb.yml"]
@@ -17,6 +22,10 @@
       "matchManagers": ["circleci"],
       "matchUpdateTypes": ["major"],
       "semanticCommitType": "feat"
+    },
+    {
+      "matchPackageNames": ["cypress"],
+      "minimumReleaseAge": "0 days"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add a 7-day `minimumReleaseAge` for all dependencies to avoid pulling in potentially unstable new releases
- Exempt the `cypress` package from this cooldown so updates are available immediately
- Enable `osvVulnerabilityAlerts` for OSV vulnerability scanning
- Add `vulnerabilityAlerts` config to bypass the 7-day cooldown for security fixes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Renovate bot settings and an example project’s pnpm metadata, with no runtime application or auth logic touched.
> 
> **Overview**
> **Renovate** now waits **7 days** after a release before opening routine dependency PRs, with **OSV vulnerability alerts** enabled and a **`vulnerabilityAlerts`** override so security fixes are not delayed. **`cypress`** is exempt from the cooldown via a dedicated **`packageRules`** entry.
> 
> The **pnpm install example** moves Cypress native-build permission from **`package.json`** (`pnpm.onlyBuiltDependencies`) to **`pnpm-workspace.yaml`** (`allowBuilds.cypress: true`), matching current pnpm workspace configuration style.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7f5a16ff04b395ee293eb707e2d7fc20c8991a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->