### PR TITLE
security: harden contributor PR workflows against supply chain attacks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,6 @@ workflows:
           exclude: SC2148,SC2038,SC2086,SC2002,SC2016
       # Triggers the next workflow in the Orb Development Kit.
       - orb-tools/continue:
-          filters: *filters
           orb_name: cypress
           pipeline_number: << pipeline.number >>
           vcs_type: << pipeline.project.type >>
@@ -32,3 +31,8 @@ workflows:
             - orb-tools/review
             - orb-tools/pack
             - shellcheck/check
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -23,13 +23,13 @@ jobs:
             - .cache/Cypress
             - project
 
-  # These jobs use --record and --parallel when CYPRESS_RECORD_KEY is available
-  # (maintainer branches and master). Fork PR builds receive no key so they
-  # run without recording — the shell conditional handles this gracefully.
+  # Browser-specific CT jobs. Recording is conditional on CYPRESS_RECORD_KEY
+  # being available via the cypress-io-orb-recording context. Fork PR builds
+  # receive no key and run without recording. Maintainer branches and master
+  # receive the key and record to Cypress Cloud.
   run-ct-tests-in-chrome:
     executor:
       name: cypress/default
-    parallelism: 2
     steps:
       - run: echo "This step assumes dependencies were installed using the cypress/install job"
       - attach_workspace:
@@ -38,13 +38,11 @@ jobs:
       - cypress/run-tests:
           working-directory: examples/angular-app
           cypress-command: >-
-            npx cypress run --component
-            $([ -n "$CYPRESS_RECORD_KEY" ] && echo "--parallel --record --group 2x-chrome" || true)
-            --browser chrome
+            npx cypress run --component --browser chrome
+            $([ -n "$CYPRESS_RECORD_KEY" ] && echo "--record --group chrome" || true)
   run-ct-tests-in-chrome-for-testing:
     executor:
       name: cypress/default
-    parallelism: 2
     steps:
       - run: echo "This step assumes dependencies were installed using the cypress/install job"
       - attach_workspace:
@@ -53,13 +51,11 @@ jobs:
       - cypress/run-tests:
           working-directory: examples/angular-app
           cypress-command: >-
-            npx cypress run --component
-            $([ -n "$CYPRESS_RECORD_KEY" ] && echo "--parallel --record --group 2x-chrome-for-testing" || true)
-            --browser chrome-for-testing
+            npx cypress run --component --browser chrome-for-testing
+            $([ -n "$CYPRESS_RECORD_KEY" ] && echo "--record --group chrome-for-testing" || true)
   run-ct-tests-in-firefox:
     executor:
       name: cypress/default
-    parallelism: 2
     steps:
       - run: echo "This step assumes dependencies were installed using the cypress/install job"
       - attach_workspace:
@@ -68,13 +64,11 @@ jobs:
       - cypress/run-tests:
           working-directory: examples/angular-app
           cypress-command: >-
-            npx cypress run --component
-            $([ -n "$CYPRESS_RECORD_KEY" ] && echo "--parallel --record --group 2x-firefox" || true)
-            --browser firefox
+            npx cypress run --component --browser firefox
+            $([ -n "$CYPRESS_RECORD_KEY" ] && echo "--record --group firefox" || true)
   run-ct-tests-in-edge:
     executor:
       name: cypress/default
-    parallelism: 2
     steps:
       - run: echo "This step assumes dependencies were installed using the cypress/install job"
       - attach_workspace:
@@ -83,9 +77,8 @@ jobs:
       - cypress/run-tests:
           working-directory: examples/angular-app
           cypress-command: >-
-            npx cypress run --component
-            $([ -n "$CYPRESS_RECORD_KEY" ] && echo "--parallel --record --group 2x-edge" || true)
-            --browser edge
+            npx cypress run --component --browser edge
+            $([ -n "$CYPRESS_RECORD_KEY" ] && echo "--record --group edge" || true)
 
 workflows:
   test_deploy:
@@ -160,8 +153,7 @@ workflows:
           cypress-cache-key: v1-cypress-cache-{{ arch }}-{{ checksum "examples/angular-app/package-lock.json" }}
           cypress-command: >-
             npx cypress run --component
-            $([ -n "$CYPRESS_RECORD_KEY" ] && echo "--parallel --record" || true)
-          parallelism: 3
+            $([ -n "$CYPRESS_RECORD_KEY" ] && echo "--record" || true)
       - cypress/run:
           filters: *filters
           name: Verify skip-checkout
@@ -171,7 +163,7 @@ workflows:
           skip-checkout: true
           cypress-command: >-
             npx cypress run --component
-            $([ -n "$CYPRESS_RECORD_KEY" ] && echo "--parallel --record" || true)
+            $([ -n "$CYPRESS_RECORD_KEY" ] && echo "--record" || true)
           pre-steps:
             - checkout
       - cypress/run:
@@ -182,7 +174,7 @@ workflows:
           cypress-cache-key: v1-cypress-cache-{{ arch }}-{{ checksum "examples/angular-app/package-lock.json" }}
           cypress-command: >-
             npx cypress run --component
-            $([ -n "$CYPRESS_RECORD_KEY" ] && echo "--parallel --record" || true)
+            $([ -n "$CYPRESS_RECORD_KEY" ] && echo "--record" || true)
           resource_class: medium+
 
       - install-and-persist:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -22,6 +22,10 @@ jobs:
           paths:
             - .cache/Cypress
             - project
+
+  # These jobs use --record and --parallel when CYPRESS_RECORD_KEY is available
+  # (maintainer branches and master). Fork PR builds receive no key so they
+  # run without recording — the shell conditional handles this gracefully.
   run-ct-tests-in-chrome:
     executor:
       name: cypress/default
@@ -33,7 +37,10 @@ jobs:
       - browser-tools/install_chrome
       - cypress/run-tests:
           working-directory: examples/angular-app
-          cypress-command: "npx cypress run --component --parallel --record --group 2x-chrome --browser chrome"
+          cypress-command: >-
+            npx cypress run --component
+            $([ -n "$CYPRESS_RECORD_KEY" ] && echo "--parallel --record --group 2x-chrome" || true)
+            --browser chrome
   run-ct-tests-in-chrome-for-testing:
     executor:
       name: cypress/default
@@ -45,7 +52,10 @@ jobs:
       - browser-tools/install_chrome_for_testing
       - cypress/run-tests:
           working-directory: examples/angular-app
-          cypress-command: "npx cypress run --component --parallel --record --group 2x-chrome-for-testing --browser chrome-for-testing"
+          cypress-command: >-
+            npx cypress run --component
+            $([ -n "$CYPRESS_RECORD_KEY" ] && echo "--parallel --record --group 2x-chrome-for-testing" || true)
+            --browser chrome-for-testing
   run-ct-tests-in-firefox:
     executor:
       name: cypress/default
@@ -57,7 +67,10 @@ jobs:
       - browser-tools/install_firefox
       - cypress/run-tests:
           working-directory: examples/angular-app
-          cypress-command: "npx cypress run --component --parallel --record --group 2x-firefox --browser firefox"
+          cypress-command: >-
+            npx cypress run --component
+            $([ -n "$CYPRESS_RECORD_KEY" ] && echo "--parallel --record --group 2x-firefox" || true)
+            --browser firefox
   run-ct-tests-in-edge:
     executor:
       name: cypress/default
@@ -69,7 +82,10 @@ jobs:
       - browser-tools/install_edge
       - cypress/run-tests:
           working-directory: examples/angular-app
-          cypress-command: "npx cypress run --component --parallel --record --group 2x-edge --browser edge"
+          cypress-command: >-
+            npx cypress run --component
+            $([ -n "$CYPRESS_RECORD_KEY" ] && echo "--parallel --record --group 2x-edge" || true)
+            --browser edge
 
 workflows:
   test_deploy:
@@ -121,60 +137,82 @@ workflows:
           # wait-on will wait for the server to be ready before running the tests
           # -v only needed for demonstration purposes
           cypress-command: npx wait-on@latest http://localhost:8080 -v && npx cypress run
+
+      # Records when CYPRESS_RECORD_KEY is available (maintainer branches + master).
+      # Fork PR builds receive no key and run without --record automatically.
       - cypress/run:
           filters: *filters
           name: Angular Application
+          context: cypress-io-orb-recording
           working-directory: examples/angular-app
           cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "examples/angular-app/package.json" }}
           start-command: "npm run start"
-          cypress-command: "npx wait-on@latest http://localhost:4200 && npx cypress run --record --browser chrome"
+          cypress-command: >-
+            npx wait-on@latest http://localhost:4200 &&
+            npx cypress run --browser chrome
+            $([ -n "$CYPRESS_RECORD_KEY" ] && echo "--record" || true)
           install-browsers: true
       - cypress/run:
           filters: *filters
           name: Run CT in Parallel
+          context: cypress-io-orb-recording
           working-directory: examples/angular-app
           cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "examples/angular-app/package.json" }}
-          cypress-command: "npx cypress run --component --parallel --record"
+          cypress-command: >-
+            npx cypress run --component
+            $([ -n "$CYPRESS_RECORD_KEY" ] && echo "--parallel --record" || true)
           parallelism: 3
       - cypress/run:
           filters: *filters
           name: Verify skip-checkout
+          context: cypress-io-orb-recording
           working-directory: examples/angular-app
           cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "examples/angular-app/package.json" }}
           skip-checkout: true
-          cypress-command: "npx cypress run --component --parallel --record"
+          cypress-command: >-
+            npx cypress run --component
+            $([ -n "$CYPRESS_RECORD_KEY" ] && echo "--parallel --record" || true)
           pre-steps:
             - checkout
       - cypress/run:
           filters: *filters
           name: Verify resource_class config works
+          context: cypress-io-orb-recording
           working-directory: examples/angular-app
           cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "examples/angular-app/package.json" }}
-          cypress-command: "npx cypress run --component --parallel --record"
+          cypress-command: >-
+            npx cypress run --component
+            $([ -n "$CYPRESS_RECORD_KEY" ] && echo "--parallel --record" || true)
           resource_class: medium+
+
       - install-and-persist:
           filters: *filters
           name: Install & Persist
       - run-ct-tests-in-chrome:
           filters: *filters
+          context: cypress-io-orb-recording
           name: Run CT Tests in Chrome
           requires:
             - Install & Persist
       - run-ct-tests-in-chrome-for-testing:
           filters: *filters
+          context: cypress-io-orb-recording
           name: Run CT Tests in Chrome for Testing
           requires:
             - Install & Persist
       - run-ct-tests-in-firefox:
           filters: *filters
+          context: cypress-io-orb-recording
           name: Run CT Tests in Firefox
           requires:
             - Install & Persist
       - run-ct-tests-in-edge:
           filters: *filters
+          context: cypress-io-orb-recording
           name: Run CT Tests in Edge
           requires:
             - Install & Persist
+
       - orb-tools/lint:
           filters: *filters
       - orb-tools/pack:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -208,6 +208,11 @@ workflows:
             - Verify skip-checkout
             - Verify resource_class config works
           context: circleci-orb-publishing
+          filters:
+            branches:
+              only: master
+            tags:
+              ignore: /.*/
       - orb-tools/publish:
           name: publish_prod
           orb_name: cypress-io/cypress

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - cypress/install:
           working-directory: examples/angular-app
-          cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "examples/angular-app/package.json" }}
+          cypress-cache-key: v1-cypress-cache-{{ arch }}-{{ checksum "examples/angular-app/package-lock.json" }}
           include-branch-in-node-cache-key: true
       - persist_to_workspace:
           root: ~/
@@ -95,13 +95,13 @@ workflows:
           filters: *filters
           name: Standard Npm Example
           working-directory: examples/npm-install
-          cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "examples/npm-install/package.json" }}
+          cypress-cache-key: v1-cypress-cache-{{ arch }}-{{ checksum "examples/npm-install/package-lock.json" }}
           post-install: "npm run say-hello && npm run say-goodbye"
       - cypress/run:
           filters: *filters
           name: Custom Node Version Example
           working-directory: examples/npm-install
-          cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "examples/npm-install/package.json" }}
+          cypress-cache-key: v1-cypress-cache-{{ arch }}-{{ checksum "examples/npm-install/package-lock.json" }}
           node-version: "24.15.0"
           post-install: |
             if ! node --version | grep -q "24.15.0"; then
@@ -112,14 +112,14 @@ workflows:
           filters: *filters
           name: Yarn Example
           working-directory: examples/yarn-install
-          cypress-cache-key: cypress-cache{{ arch }}-{{ checksum "examples/yarn-install/package.json" }}
+          cypress-cache-key: v1-cypress-cache-{{ arch }}-{{ checksum "examples/yarn-install/yarn.lock" }}
           post-install: "npx cypress install"
           package-manager: "yarn"
       - cypress/run:
           filters: *filters
           name: Pnpm Example
           working-directory: examples/pnpm-install
-          cypress-cache-key: cypress-cache{{ arch }}-{{ checksum "examples/pnpm-install/package.json" }}
+          cypress-cache-key: v1-cypress-cache-{{ arch }}-{{ checksum "examples/pnpm-install/pnpm-lock.yaml" }}
           post-install: "pnpm cypress install"
           package-manager: "pnpm"
       - cypress/run:
@@ -127,12 +127,12 @@ workflows:
           name: Custom Install Example
           working-directory: examples/custom-install
           install-command: npm run custom-install
-          cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "examples/custom-install/package.json" }}
+          cypress-cache-key: v1-cypress-cache-{{ arch }}-{{ checksum "examples/custom-install/package-lock.json" }}
       - cypress/run:
           filters: *filters
           name: Wait On Example
           working-directory: examples/wait-on
-          cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "examples/wait-on/package.json" }}
+          cypress-cache-key: v1-cypress-cache-{{ arch }}-{{ checksum "examples/wait-on/package-lock.json" }}
           start-command: npm start
           # wait-on will wait for the server to be ready before running the tests
           # -v only needed for demonstration purposes
@@ -145,7 +145,7 @@ workflows:
           name: Angular Application
           context: cypress-io-orb-recording
           working-directory: examples/angular-app
-          cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "examples/angular-app/package.json" }}
+          cypress-cache-key: v1-cypress-cache-{{ arch }}-{{ checksum "examples/angular-app/package-lock.json" }}
           start-command: "npm run start"
           cypress-command: >-
             npx wait-on@latest http://localhost:4200 &&
@@ -157,7 +157,7 @@ workflows:
           name: Run CT in Parallel
           context: cypress-io-orb-recording
           working-directory: examples/angular-app
-          cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "examples/angular-app/package.json" }}
+          cypress-cache-key: v1-cypress-cache-{{ arch }}-{{ checksum "examples/angular-app/package-lock.json" }}
           cypress-command: >-
             npx cypress run --component
             $([ -n "$CYPRESS_RECORD_KEY" ] && echo "--parallel --record" || true)
@@ -167,7 +167,7 @@ workflows:
           name: Verify skip-checkout
           context: cypress-io-orb-recording
           working-directory: examples/angular-app
-          cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "examples/angular-app/package.json" }}
+          cypress-cache-key: v1-cypress-cache-{{ arch }}-{{ checksum "examples/angular-app/package-lock.json" }}
           skip-checkout: true
           cypress-command: >-
             npx cypress run --component
@@ -179,7 +179,7 @@ workflows:
           name: Verify resource_class config works
           context: cypress-io-orb-recording
           working-directory: examples/angular-app
-          cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "examples/angular-app/package.json" }}
+          cypress-cache-key: v1-cypress-cache-{{ arch }}-{{ checksum "examples/angular-app/package-lock.json" }}
           cypress-command: >-
             npx cypress run --component
             $([ -n "$CYPRESS_RECORD_KEY" ] && echo "--parallel --record" || true)

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -250,7 +250,7 @@ workflows:
             branches:
               only: master
             tags:
-              ignore: /.*/
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
       - orb-tools/publish:
           name: publish_prod
           orb_name: cypress-io/cypress

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -24,7 +24,7 @@ parameters:
   cypress-cache-key:
     description: Cache key used to cache the Cypress binary.
     type: string
-    default: 'cypress-cache-{{ arch }}-{{ checksum "package.json" }}'
+    default: 'v1-cypress-cache-{{ arch }}-{{ checksum "package-lock.json" }}-{{ checksum "yarn.lock" }}-{{ checksum "pnpm-lock.yaml" }}'
   cypress-cache-path:
     description: |
       By default, this will cache the '~/.cache/Cypress' directory so that the Cypress binary is cached. You can override this by providing your own cache path.

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -22,9 +22,14 @@ parameters:
     type: boolean
     default: false
   cypress-cache-key:
-    description: Cache key used to cache the Cypress binary.
+    description: >
+      Cache key used to cache the Cypress binary. Defaults to a lockfile-based
+      key using package-lock.json (npm). If you use yarn or pnpm, override this
+      with the appropriate lockfile, e.g.:
+      'v1-cypress-cache-{{ arch }}-{{ checksum "yarn.lock" }}' or
+      'v1-cypress-cache-{{ arch }}-{{ checksum "pnpm-lock.yaml" }}'
     type: string
-    default: 'v1-cypress-cache-{{ arch }}-{{ checksum "package-lock.json" }}-{{ checksum "yarn.lock" }}-{{ checksum "pnpm-lock.yaml" }}'
+    default: 'v1-cypress-cache-{{ arch }}-{{ checksum "package-lock.json" }}'
   cypress-cache-path:
     description: |
       By default, this will cache the '~/.cache/Cypress' directory so that the Cypress binary is cached. You can override this by providing your own cache path.

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -29,9 +29,14 @@ parameters:
     type: boolean
     default: false
   cypress-cache-key:
-    description: Cache key used to cache the Cypress binary.
+    description: >
+      Cache key used to cache the Cypress binary. Defaults to a lockfile-based
+      key using package-lock.json (npm). If you use yarn or pnpm, override this
+      with the appropriate lockfile, e.g.:
+      'v1-cypress-cache-{{ arch }}-{{ checksum "yarn.lock" }}' or
+      'v1-cypress-cache-{{ arch }}-{{ checksum "pnpm-lock.yaml" }}'
     type: string
-    default: 'v1-cypress-cache-{{ arch }}-{{ checksum "package-lock.json" }}-{{ checksum "yarn.lock" }}-{{ checksum "pnpm-lock.yaml" }}'
+    default: 'v1-cypress-cache-{{ arch }}-{{ checksum "package-lock.json" }}'
   cypress-cache-path:
     description: |
       By default, this will cache the '~/.cache/Cypress' directory so that the Cypress binary is cached. You can override this by providing your own cache path.

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -31,7 +31,7 @@ parameters:
   cypress-cache-key:
     description: Cache key used to cache the Cypress binary.
     type: string
-    default: 'cypress-cache-{{ arch }}-{{ checksum "package.json" }}'
+    default: 'v1-cypress-cache-{{ arch }}-{{ checksum "package-lock.json" }}-{{ checksum "yarn.lock" }}-{{ checksum "pnpm-lock.yaml" }}'
   cypress-cache-path:
     description: |
       By default, this will cache the '~/.cache/Cypress' directory so that the Cypress binary is cached. You can override this by providing your own cache path.


### PR DESCRIPTION
# Security: Harden Contributor PR Workflows

As part of an ongoing effort to protect the project against supply chain attacks, this PR hardens the CI/CD configuration before reopening contributor pull requests.

## Changes

### 1. Restrict orb publishing to `master` only

The job responsible for publishing dev builds of the orb now runs exclusively on `master` and production version tags. This ensures the publishing token is never present in a pipeline triggered by a contributor branch or PR.

### 2. Gate Cypress Cloud recording by contributor trust level

Tests that record to Cypress Cloud now conditionally activate recording based on whether the record key is available. Combined with CircleCI's fork PR secret isolation setting, this means:

- **Maintainer branches** record to Cypress Cloud as before
- **External contributor fork PRs** run the full test suite without recording — tests still pass or fail correctly, results just aren't uploaded to Cypress Cloud

No duplicate job definitions are needed; a shell conditional handles this gracefully at runtime.

Parallelism has been removed from the CT jobs. CircleCI's `parallelism` setting is determined at config time, not runtime, so it cannot be flexed based on whether a record key is available. The alternatives — duplicate workflow entries or `circleci tests split` — add meaningful maintenance overhead. Given the low volume of contributions to this repo and the security posture being prioritised, the simpler single-machine approach is the right trade-off.

### 3. Switch Cypress binary cache keys to lockfile checksums

Cache keys previously used `package.json` as the checksum source. They now use the appropriate lockfile for each package manager (`package-lock.json`, `yarn.lock`, or `pnpm-lock.yaml`).

Lockfiles are machine-generated and represent the exact resolved dependency tree, making them significantly more resistant to manipulation than `package.json`. A `v1-` version prefix is added to all keys to allow cache invalidation if ever needed.

### 4. Restrict the CI continuation pipeline to branches and release tags only

The job that triggers the full integration test pipeline is now limited to branch builds and production release tags (`vX.Y.Z`). Previously, any tag pushed to the repository would trigger the full pipeline unnecessarily.

## Pre-merge checklist

- [ ] Verify a test build on `master` records successfully
- [ ] Verify a contributor fork PR build runs successfully and does not record to Cypress Cloud