### PR TITLE
security: require maintainer approval before running CI for contributor fork PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ workflows:
       # Triggers the next workflow in the Orb Development Kit.
       # Maintainer branches and tags run immediately (no approval gate).
       - orb-tools/continue:
+          name: orb-tools/continue
           orb_name: cypress
           pipeline_number: << pipeline.number >>
           vcs_type: << pipeline.project.type >>
@@ -46,6 +47,7 @@ workflows:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
       # Contributor fork PRs — same continuation but gated behind approval.
       - orb-tools/continue:
+          name: orb-tools/continue
           orb_name: cypress
           pipeline_number: << pipeline.number >>
           vcs_type: << pipeline.project.type >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,32 +22,16 @@ workflows:
           filters: *filters
           exclude: SC2148,SC2038,SC2086,SC2002,SC2016
       # Fork PRs (branch name matches pull/<number>) require manual approval
-      # before the downstream test-deploy pipeline runs.
+      # before the downstream test-deploy pipeline runs. CircleCI treats
+      # filtered-out jobs as auto-passing in requires, so on maintainer
+      # branches approve-contributor-pr never schedules and orb-tools/continue
+      # fires immediately — no impact on the existing maintainer workflow.
       - approve-contributor-pr:
           type: approval
           filters:
             branches:
               only: /^pull\/[0-9]+/
-      # Triggers the next workflow in the Orb Development Kit.
-      # Maintainer branches and tags run immediately (no approval gate).
       - orb-tools/continue:
-          name: orb-tools/continue
-          orb_name: cypress
-          pipeline_number: << pipeline.number >>
-          vcs_type: << pipeline.project.type >>
-          requires:
-            - orb-tools/lint
-            - orb-tools/review
-            - orb-tools/pack
-            - shellcheck/check
-          filters:
-            branches:
-              ignore: /^pull\/[0-9]+/
-            tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
-      # Contributor fork PRs — same continuation but gated behind approval.
-      - orb-tools/continue:
-          name: orb-tools/continue
           orb_name: cypress
           pipeline_number: << pipeline.number >>
           vcs_type: << pipeline.project.type >>
@@ -59,4 +43,6 @@ workflows:
             - approve-contributor-pr
           filters:
             branches:
-              only: /^pull\/[0-9]+/
+              only: /.*/
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,15 @@ workflows:
       - shellcheck/check:
           filters: *filters
           exclude: SC2148,SC2038,SC2086,SC2002,SC2016
+      # Fork PRs (branch name matches pull/<number>) require manual approval
+      # before the downstream test-deploy pipeline runs.
+      - approve-contributor-pr:
+          type: approval
+          filters:
+            branches:
+              only: /^pull\/[0-9]+/
       # Triggers the next workflow in the Orb Development Kit.
+      # Maintainer branches and tags run immediately (no approval gate).
       - orb-tools/continue:
           orb_name: cypress
           pipeline_number: << pipeline.number >>
@@ -33,6 +41,20 @@ workflows:
             - shellcheck/check
           filters:
             branches:
-              only: /.*/
+              ignore: /^pull\/[0-9]+/
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+      # Contributor fork PRs — same continuation but gated behind approval.
+      - orb-tools/continue:
+          orb_name: cypress
+          pipeline_number: << pipeline.number >>
+          vcs_type: << pipeline.project.type >>
+          requires:
+            - orb-tools/lint
+            - orb-tools/review
+            - orb-tools/pack
+            - shellcheck/check
+            - approve-contributor-pr
+          filters:
+            branches:
+              only: /^pull\/[0-9]+/


### PR DESCRIPTION
## Summary

Adds a manual approval gate in CircleCI before the test suite runs for contributor fork pull requests. This prevents untrusted code from executing in CI without a maintainer first reviewing and approving the build.

## How it works

CircleCI represents fork PRs as a branch named `pull/<number>`. This change uses that pattern to split the `orb-tools/continue` job into two entries:

- **Maintainer branches and tags** — lint, pack, review, and shellcheck run immediately, then `orb-tools/continue` fires as before. No change to the existing workflow.
- **Contributor fork PRs** (`pull/*`) — the same lint/pack/review/shellcheck jobs run, but `orb-tools/continue` (which triggers the full downstream test pipeline) is blocked behind an `approve-contributor-pr` approval job. A maintainer must click approve in the CircleCI UI before the test suite runs.
<img width="1721" height="277" alt="Screenshot 2026-06-10 at 9 50 32 AM" src="https://github.com/user-attachments/assets/8ad634ee-6487-4343-ad62-519cf33389c3" />



## Why

Supply chain attacks via CI are a real and growing vector. Running contributor code automatically — even in a sandboxed environment — can expose secrets, poison caches, or execute malicious `postinstall` hooks before anyone has reviewed the change. Requiring explicit maintainer approval before CI runs ensures code is vetted before it executes.

This mirrors the pattern used in `cypress-io/cypress`, where all contributor fork PR jobs gate behind `approve-contributor-pr` before any builds run.

## What is not affected

- Maintainer branch PRs — no approval step, no change in behavior
- Tag-triggered production releases — unaffected
- The lint, pack, review, and shellcheck jobs — these run immediately for all PRs (they do not execute contributor code)
- GitHub Actions triage workflows — these call shared reusable workflows from `cypress-io/cypress` that already handle collaborator checks internally

## Test plan

- [x] Open a fork PR and verify CircleCI pauses at `approve-contributor-pr` before the test suite runs (see https://github.com/cypress-io/circleci-orb/pull/585)
- [x] Approve the gate and verify the downstream `test-deploy` pipeline runs successfully
- [x] Open a maintainer branch PR and verify CI runs immediately with no approval step


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI security posture for fork PRs; maintainer workflows are intended to be unchanged via filtered approval auto-pass behavior.
> 
> **Overview**
> Adds a **manual approval gate** in CircleCI so contributor **fork PRs** (`pull/<number>` branches) cannot trigger the full downstream **test-deploy** pipeline until a maintainer approves **`approve-contributor-pr`**.
> 
> **`orb-tools/continue`** now **requires** that approval job in addition to lint, pack, review, and shellcheck. On maintainer branches the approval job is filtered out and CircleCI treats it as satisfied, so **maintainer PRs and tag releases behave unchanged**. Lint/pack/review/shellcheck still run immediately for all PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77fc659881d829979b08c88841593f489edb87e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->