### PR TITLE
test: add allowScripts to npm examples

### DIFF
--- a/examples/angular-app/package.json
+++ b/examples/angular-app/package.json
@@ -45,5 +45,14 @@
     "workerDirectory": [
       "public"
     ]
+  },
+  "allowScripts": {
+    "@parcel/watcher": true,
+    "@tailwindcss/oxide": true,
+    "cypress": true,
+    "esbuild": true,
+    "lmdb": true,
+    "msgpackr-extract": true,
+    "msw": true
   }
 }

--- a/examples/custom-install/package.json
+++ b/examples/custom-install/package.json
@@ -10,5 +10,8 @@
   "private": true,
   "devDependencies": {
     "cypress": "^15.0.0"
+  },
+  "allowScripts": {
+    "cypress": true
   }
 }

--- a/examples/npm-install/package.json
+++ b/examples/npm-install/package.json
@@ -11,5 +11,8 @@
   "private": true,
   "devDependencies": {
     "cypress": "^15.0.0"
+  },
+  "allowScripts": {
+    "cypress": true
   }
 }

--- a/examples/wait-on/package.json
+++ b/examples/wait-on/package.json
@@ -9,5 +9,8 @@
   "private": true,
   "devDependencies": {
     "cypress": "^15.0.0"
+  },
+  "allowScripts": {
+    "cypress": true
   }
 }


### PR DESCRIPTION
## Current behavior

The following projects in the [examples](https://github.com/cypress-io/circleci-orb/tree/master/examples) directory are based on npm

- [angular-app](https://github.com/cypress-io/circleci-orb/tree/master/examples/angular-app)
- [custom-install](https://github.com/cypress-io/circleci-orb/tree/master/examples/custom-install)
- [npm-install](https://github.com/cypress-io/circleci-orb/tree/master/examples/npm-install)
- [wait-on](https://github.com/cypress-io/circleci-orb/tree/master/examples/wait-on)

If these examples are installed locally using Node.js 24.18.0 LTS, with npm@11.16.0 bundled, they produce warnings:

```console
npm warn allow-scripts 1 package has install scripts not yet covered by allowScripts:
npm warn allow-scripts   cypress@15.0.0 (postinstall: node index.js --exec install)
```

- [angular-app](https://github.com/cypress-io/circleci-orb/tree/master/examples/angular-app) produces more warnings:

```console
npm warn allow-scripts 7 packages have install scripts not yet covered by allowScripts:
npm warn allow-scripts   @parcel/watcher@2.5.1 (install: node scripts/build-from-source.js)
npm warn allow-scripts   @tailwindcss/oxide@4.1.11 (postinstall: node ./scripts/install.js)
npm warn allow-scripts   cypress@15.0.0 (postinstall: node index.js --exec install)
npm warn allow-scripts   esbuild@0.25.5 (postinstall: node install.js)
npm warn allow-scripts   lmdb@3.4.1 (install: node-gyp-build-optional-packages)
npm warn allow-scripts   msgpackr-extract@3.0.3 (install: node-gyp-build-optional-packages)
npm warn allow-scripts   msw@2.10.5 (postinstall: node -e "import('./config/scripts/postinstall.js').catch(() => void 0)")
```

## Change

In each of the npm examples directories, execute the following:

```shell
npm ci
npm approve-scripts --all --no-allow-scripts-pin
```

## Verification

Ubuntu 24.04.4 LTS, Node.js 24.18.0 LTS

```shell
git clone https://github.com/cypress-io/circleci-orb
cd circleci-orb
git clean -xfd # if repeating
rm -rf ~/.cache/Cypress # if repeating

cd examples

cd angular-app
npm ci
cd ..

cd custom-install
npm ci
cd ..

cd npm-install
npm ci
cd ..

cd wait-on
npm ci
cd ..

cd ..
```

Confirm no `npm allowScripts`  warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only package.json metadata with no runtime, auth, or orb logic changes.
> 
> **Overview**
> Adds npm **`allowScripts`** configuration to the four npm-based CircleCI orb examples so **`npm ci`** on npm 11+ (Node 24 LTS) no longer emits **`allow-scripts`** warnings for packages that run install/postinstall hooks.
> 
> **`angular-app`** whitelists seven dependencies (including Cypress, MSW, Tailwind oxide, esbuild, and native optional builds). **`custom-install`**, **`npm-install`**, and **`wait-on`** only allow **`cypress`**. **`angular-app/package.json`** also fixes the closing brace formatting at the end of the file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca1847db71b01bb9001892420ce3702125b83606. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->