### PR TITLE
feat: add pnpm-version parameter to install command and run job

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -108,6 +108,19 @@ workflows:
           package-manager: "pnpm"
       - cypress/run:
           filters: *filters
+          name: Custom Pnpm Version Example
+          working-directory: examples/pnpm-install
+          cypress-cache-key: cypress-cache{{ arch }}-{{ checksum "examples/pnpm-install/package.json" }}
+          package-manager: "pnpm"
+          pnpm-version: "11.10.0"
+          post-install: |
+            if ! pnpm --version | grep -q "11.10.0"; then
+                echo "pnpm version 11.10.0 not found"
+                exit 1
+            fi
+            pnpm cypress install
+      - cypress/run:
+          filters: *filters
           name: Custom Install Example
           working-directory: examples/custom-install
           install-command: npm run custom-install
@@ -196,6 +209,7 @@ workflows:
             - Custom Node Version Example
             - Yarn Example
             - Pnpm Example
+            - Custom Pnpm Version Example
             - Custom Install Example
             - Wait On Example
             - Angular Application
@@ -223,6 +237,7 @@ workflows:
             - Custom Node Version Example
             - Yarn Example
             - Pnpm Example
+            - Custom Pnpm Version Example
             - Custom Install Example
             - Wait On Example
             - Angular Application

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -48,6 +48,12 @@ parameters:
     enum: ["npm", "yarn", "yarn-berry", "pnpm"]
     default: "npm"
     description: Select the default node package manager to use. npm v5+ Required.
+  pnpm-version:
+    type: string
+    default: ""
+    description: |
+      Pick a specific version of pnpm to install (if no version is specified, the latest stable version will be installed): https://github.com/pnpm/pnpm/releases
+      Only used when `package-manager` is set to `pnpm`. Pinning a version is recommended when installs go through a registry proxy or firewall that may not resolve the latest release.
   skip-checkout:
     type: boolean
     default: false
@@ -75,6 +81,7 @@ steps:
       steps:
         - node/install:
             install-pnpm: true
+            pnpm-version: << parameters.pnpm-version >>
   - node/install-packages:
       override-ci-command: << parameters.install-command >>
       app-dir: << parameters.working-directory >>

--- a/src/examples/pnpm.yml
+++ b/src/examples/pnpm.yml
@@ -10,5 +10,7 @@ usage:
       jobs:
         - cypress/run:
             package-manager: "pnpm"
+            # Optionally pin the pnpm version to install (defaults to latest stable)
+            pnpm-version: "11.10.0"
             start-command: "pnpm start"
             install-command: "pnpm install --frozen-lockfile"

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -55,6 +55,12 @@ parameters:
     enum: ["npm", "yarn", "yarn-berry", "pnpm"]
     default: "npm"
     description: Select the default node package manager to use. npm v5+ Required.
+  pnpm-version:
+    type: string
+    default: ""
+    description: |
+      Pick a specific version of pnpm to install (if no version is specified, the latest stable version will be installed): https://github.com/pnpm/pnpm/releases
+      Only used when `package-manager` is set to `pnpm`. Pinning a version is recommended when installs go through a registry proxy or firewall that may not resolve the latest release.
   start-command:
     description: Command used to start your local dev server for Cypress to tests against
     type: string
@@ -103,6 +109,7 @@ steps:
       node-cache-version: << parameters.node-cache-version >>
       working-directory: << parameters.working-directory >>
       package-manager: << parameters.package-manager >>
+      pnpm-version: << parameters.pnpm-version >>
       include-branch-in-node-cache-key: << parameters.include-branch-in-node-cache-key >>
       install-browsers: << parameters.install-browsers >>
       skip-checkout: << parameters.skip-checkout >>


### PR DESCRIPTION
When package-manager is set to pnpm, the orb runs node/install with install-pnpm: true and no version, so the node orb resolves the latest pnpm release (via jsdelivr) and runs npm install -g pnpm@<latest>. Behind registry proxies or version-filtering firewalls (Artifactory, Verdaccio, release-age policies), the freshly released version may not be resolvable from the npm registry yet, failing the install with ETARGET: No matching version found for pnpm@<latest>.

Add a pnpm-version parameter to the install command and the run job, threaded through to node/install (which already supports pnpm-version), so users can pin the pnpm version. Defaults to the current behavior of installing the latest stable release.


Claude-Session: https://claude.ai/code/session_011RtNiB1ZDoFcd7oBBJFM8C